### PR TITLE
Optimize h.264 NAL splitting

### DIFF
--- a/codecs/h264_packet.go
+++ b/codecs/h264_packet.go
@@ -7,39 +7,85 @@ const (
 	fuaHeaderSize = 2
 )
 
-func emitNalus(nals []byte, emit func([]byte)) {
-	nextInd := func(nalu []byte, start int) (indStart int, indLen int) {
-		zeroCount := 0
+// I am sorry world, for the OPTIMIZATIONS I have bestowed upon thee.
+// This parses an Annex.B bitstream and returns the next NALU and any remaining data.
+// Annex.B uses a start-code of either 001 or 0001.
+// Each NALU is prefixed with a start-code, which runs until the next start-code (or EOF)
+func nextNALU(data []byte) (nalu []byte, remaining []byte) {
+	i := 0
 
-		for i, b := range nalu[start:] {
-			if b == 0 {
-				zeroCount++
-				continue
-			} else if b == 1 {
-				if zeroCount >= 2 {
-					return start + i - zeroCount, zeroCount + 1
+	// Loop over the entire data, except for the last 3 bytes.
+	// We know that we can't fit a start code in that size plus it would cause a range error.
+	for i+2 < len(data) {
+		// We want to check if the current index is the start of the start code, otherwise advance.
+
+		// Check the 3rd byte first, because it's the most useful.
+		switch data[i+2] {
+		case 0:
+			// state: ? ? 0
+
+			switch {
+			case data[i+1] != 0:
+				// state: ? n 0
+
+				// The 3rd byte could be the start of a code.
+				i += 2
+			case data[i] != 0:
+				// state: n 0 0
+
+				// The 2nd byte could be the start of a code.
+				i++
+			default:
+				// state: 0 0 0 ?
+
+				// I don't think it's possible to have three zeroes except for a start code.
+				// But to be safe, let's handle edge cases.
+
+				if i+3 < len(data) {
+					switch data[i+3] {
+					case 0:
+						// state: 0 0 0 0
+
+						// This shouldn't be possible but I guess it could be part of a start code.
+						i++
+					case 1:
+						// state: 0 0 0 1
+						return data[:i], data[i+4:]
+					default:
+						// state: 0 0 0 n
+
+						// No start code possible so we can advance 4 bytes.
+						i += 4
+					}
 				}
+
+				// state: 0 0 0 EOF
+
+				return data, nil
 			}
-			zeroCount = 0
+		case 1:
+			// state: ? ? 1
+
+			if data[i] == 0 && data[i+1] == 0 {
+				// state: 0 0 1
+				return data[:i], data[i+3:]
+			}
+
+			// state: n ? 1 or ? n 1
+
+			// Neither of these could be part of a start code.
+			i += 3
+		default:
+			// state: ? ? n
+
+			// If it's not 0 or 1, then there's no start code nor can it be part of a start code.
+			// So most of the time, we advance 3 bytes at once instead of just 1 byte at a time.
+			i += 3
 		}
-		return -1, -1
 	}
 
-	nextIndStart, nextIndLen := nextInd(nals, 0)
-	if nextIndStart == -1 {
-		emit(nals)
-	} else {
-		for nextIndStart != -1 {
-			prevStart := nextIndStart + nextIndLen
-			nextIndStart, nextIndLen = nextInd(nals, prevStart)
-			if nextIndStart != -1 {
-				emit(nals[prevStart:nextIndStart])
-			} else {
-				// Emit until end of stream, no end indicator found
-				emit(nals[prevStart:])
-			}
-		}
-	}
+	// At the end of the file, return what we've got.
+	return data, nil
 }
 
 // Payload fragments a H264 packet across one or more byte arrays
@@ -50,12 +96,20 @@ func (p *H264Payloader) Payload(mtu int, payload []byte) [][]byte {
 		return payloads
 	}
 
-	emitNalus(payload, func(nalu []byte) {
+	for len(payload) > 0 {
+		nalu, remaining := nextNALU(payload)
+		payload = remaining
+
+		if len(nalu) == 0 {
+			// This will only be true for the first start code.
+			continue
+		}
+
 		naluType := nalu[0] & 0x1F
 		naluRefIdc := nalu[0] & 0x60
 
 		if naluType == 9 || naluType == 12 {
-			return
+			continue
 		}
 
 		// Single NALU
@@ -63,7 +117,7 @@ func (p *H264Payloader) Payload(mtu int, payload []byte) [][]byte {
 			out := make([]byte, len(nalu))
 			copy(out, nalu)
 			payloads = append(payloads, out)
-			return
+			continue
 		}
 
 		// FU-A
@@ -87,7 +141,7 @@ func (p *H264Payloader) Payload(mtu int, payload []byte) [][]byte {
 		naluDataRemaining := naluDataLength
 
 		if min(maxFragmentSize, naluDataRemaining) <= 0 {
-			return
+			continue
 		}
 
 		for naluDataRemaining > 0 {
@@ -124,7 +178,7 @@ func (p *H264Payloader) Payload(mtu int, payload []byte) [][]byte {
 			naluDataIndex += currentFragmentSize
 		}
 
-	})
+	}
 
 	return payloads
 }

--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -2,48 +2,79 @@ package codecs
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestH264Payloader_Payload(t *testing.T) {
+	assert := assert.New(t)
+
 	pck := H264Payloader{}
 	payload := []byte{0x90, 0x90, 0x90}
 
 	// Positive MTU, nil payload
 	res := pck.Payload(1, nil)
-	if len(res) != 0 {
-		t.Fatal("Generated payload should be empty")
-	}
+	assert.Len(res, 0, "Generated payload should be empty")
 
 	// Negative MTU, small payload
 	res = pck.Payload(0, payload)
-	if len(res) != 0 {
-		t.Fatal("Generated payload should be empty")
-	}
+	assert.Len(res, 0, "Generated payload should be empty")
 
 	// 0 MTU, small payload
 	res = pck.Payload(0, payload)
-	if len(res) != 0 {
-		t.Fatal("Generated payload should be empty")
-	}
+	assert.Len(res, 0, "Generated payload should be empty")
 
 	// Positive MTU, small payload
 	res = pck.Payload(1, payload)
-	if len(res) != 0 {
-		t.Fatal("Generated payload should be empty")
-	}
+	assert.Len(res, 0, "Generated payload should be empty")
 
 	// Positive MTU, small payload
 	res = pck.Payload(5, payload)
-	if len(res) != 1 {
-		t.Fatal("Generated payload shouldn't be empty")
-	}
-	if len(res[0]) != len(payload) {
-		t.Fatal("Generated payload should be the same size as original payload size")
-	}
+	assert.Len(res, 1, "Generated payload shouldn't be empty")
+	assert.Len(res[0], len(payload), "Generated payload should be the same size as original payload size")
 
 	// Nalu type 9 or 12
 	res = pck.Payload(5, []byte{0x09, 0x00, 0x00})
-	if len(res) != 0 {
-		t.Fatal("Generated payload should be empty")
+	assert.Len(res, 0, "Generated payload should be empty")
+}
+
+func TestNextNALU(t *testing.T) {
+	assert := assert.New(t)
+
+	input := []byte{
+		0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x1f, 0x01,
+		0x00, 0x00, 0x01, 0x80, 0x00, 0x00, 0x03, 0x00, 0x7a,
+		0x00, 0x00, 0x00, 0x01, 0xab, 0xbc, 0xef,
+	}
+
+	// The first NALU is empty to trim off the start code.
+	nalu, input := nextNALU(input)
+	assert.Len(nalu, 0)
+
+	nalu, input = nextNALU(input)
+	assert.Equal([]byte{0x67, 0x42, 0x00, 0x1f, 0x01}, nalu)
+
+	nalu, input = nextNALU(input)
+	assert.Equal([]byte{0x80, 0x00, 0x00, 0x03, 0x00, 0x7a}, nalu)
+
+	nalu, input = nextNALU(input)
+	assert.Equal([]byte{0xab, 0xbc, 0xef}, nalu)
+
+	assert.Len(input, 0)
+}
+
+func BenchmarkNextNALU(b *testing.B) {
+	input := []byte{
+		0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x1f, 0x01,
+		0x00, 0x00, 0x01, 0x80, 0x00, 0x00, 0x03, 0x00, 0x7a,
+		0x00, 0x00, 0x00, 0x01, 0xab, 0xbc, 0xef,
+	}
+
+	for i := 0; i < b.N; i++ {
+		remaining := input
+
+		for len(remaining) > 0 {
+			_, remaining = nextNALU(remaining)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pions/rtp
 
 go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
It's not a bottleneck, I just thought there was a bug and then got
carried away. It's probably faster on larger NALUs.

As compared to `emitNalu`:
```
name        old time/op  new time/op  delta
nextNALU-8  40.1ns ± 0%  22.6ns ± 1%  -43.48%
```