### PR TITLE
Disallow stdlib functions that print to stdio

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -4,7 +4,7 @@ set -e
 # Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github "
-DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(')
+DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(' 'fmt.Println(' 'fmt.Printf(' 'log.Print(' 'log.Println(' 'log.Printf(')
 
 
 for disallowedFunction in "${DISALLOWED_FUNCTIONS[@]}"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Michael MacDonald](https://github.com/mjmac)
 * [Luke Curley](https://github.com/kixelated) *Performance*
 * [Antoine Baché](https://github.com/Antonito) *Fixed crashes*
+* [Hugo Arregui](https://github.com/hugoArregui)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
All printing to stdio must be done via pion/logging, all calls to common printing functions will not cause CI to fail

Related to https://github.com/pion/webrtc/issues/361