### PR TITLE
Add PartitionHeadChecker interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Antoine Baché](https://github.com/Antonito) *Fixed crashes*
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Raphael Derosso Pereira](https://github.com/raphaelpereira)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/codecs/opus_packet.go
+++ b/codecs/opus_packet.go
@@ -34,3 +34,15 @@ func (p *OpusPacket) Unmarshal(packet []byte) ([]byte, error) {
 	p.Payload = packet
 	return packet, nil
 }
+
+// OpusPartitionHeadChecker checks Opus partition head
+type OpusPartitionHeadChecker struct{}
+
+// IsPartitionHead checks whether if this is a head of the Opus partition
+func (*OpusPartitionHeadChecker) IsPartitionHead(packet []byte) bool {
+	p := &OpusPacket{}
+	if _, err := p.Unmarshal(packet); err != nil {
+		return false
+	}
+	return true
+}

--- a/codecs/opus_packet_test.go
+++ b/codecs/opus_packet_test.go
@@ -68,3 +68,17 @@ func TestOpusPayloader_Payload(t *testing.T) {
 	}
 
 }
+
+func TestOpusPartitionHeadChecker_IsPartitionHead(t *testing.T) {
+	checker := &OpusPartitionHeadChecker{}
+	t.Run("SmallPacket", func(t *testing.T) {
+		if checker.IsPartitionHead([]byte{}) {
+			t.Fatal("Small packet should not be the head of a new partition")
+		}
+	})
+	t.Run("NormalPacket", func(t *testing.T) {
+		if !checker.IsPartitionHead([]byte{0x00, 0x00}) {
+			t.Fatal("All OPUS RTP packet should be the head of a new partition")
+		}
+	})
+}

--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -134,3 +134,15 @@ func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
 	p.Payload = payload[payloadIndex:]
 	return p.Payload, nil
 }
+
+// VP8PartitionHeadChecker checks VP8 partition head
+type VP8PartitionHeadChecker struct{}
+
+// IsPartitionHead checks whether if this is a head of the VP8 partition
+func (*VP8PartitionHeadChecker) IsPartitionHead(packet []byte) bool {
+	p := &VP8Packet{}
+	if _, err := p.Unmarshal(packet); err != nil {
+		return false
+	}
+	return p.S == 1
+}

--- a/codecs/vp8_packet_test.go
+++ b/codecs/vp8_packet_test.go
@@ -141,3 +141,22 @@ func TestVP8Payloader_Payload(t *testing.T) {
 		t.Fatal("Generated payload should be the same size as original payload size")
 	}
 }
+
+func TestVP8PartitionHeadChecker_IsPartitionHead(t *testing.T) {
+	checker := &VP8PartitionHeadChecker{}
+	t.Run("SmallPacket", func(t *testing.T) {
+		if checker.IsPartitionHead([]byte{0x00}) {
+			t.Fatal("Small packet should not be the head of a new partition")
+		}
+	})
+	t.Run("SFlagON", func(t *testing.T) {
+		if !checker.IsPartitionHead([]byte{0x10, 0x00, 0x00, 0x00}) {
+			t.Fatal("Packet with S flag should be the head of a new partition")
+		}
+	})
+	t.Run("SFlagOFF", func(t *testing.T) {
+		if checker.IsPartitionHead([]byte{0x00, 0x00, 0x00, 0x00}) {
+			t.Fatal("Packet without S flag should not be the head of a new partition")
+		}
+	})
+}

--- a/partitionheadchecker.go
+++ b/partitionheadchecker.go
@@ -1,0 +1,6 @@
+package rtp
+
+// PartitionHeadChecker is the interface that checks whether the packet is keyframe or not
+type PartitionHeadChecker interface {
+	IsPartitionHead([]byte) bool
+}


### PR DESCRIPTION
Add an interface to check whether the given packet is the beginning of a new frame partition.
`OpusPartitionHeadChecker` and `VP8PartitionHeadChecker` are implemented.

Intended to be used in https://github.com/pion/webrtc/pull/932.

If there is better interface naming for this, please comment.