### PR TITLE
Fix Packet.Raw set by Packet.Marshal

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -264,7 +264,7 @@ func (p *Packet) MarshalTo(buf []byte) (n int, err error) {
 	}
 
 	m := copy(buf[n:], p.Payload)
-	p.Raw = buf[n : n+m]
+	p.Raw = buf[:n+m]
 
 	return n + m, nil
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -1,6 +1,7 @@
 package rtp
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 )
@@ -91,6 +92,43 @@ func TestExtension(t *testing.T) {
 	}
 	if _, err := p.Marshal(); err == nil {
 		t.Fatal("Marshal did not error on packet with invalid extension length")
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	rawPkt := []byte{
+		0x00, 0x10, 0x23, 0x45, 0x12, 0x34, 0x45, 0x67, 0xCC, 0xDD, 0xEE, 0xFF,
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+	}
+	payload := rawPkt[12:]
+
+	p := &Packet{}
+	if err := p.Unmarshal(rawPkt); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(rawPkt, p.Raw) {
+		t.Errorf("p.Raw must be same as rawPkt.\n p.Raw: %+v,\nrawPkt: %+v", p.Raw, rawPkt)
+	}
+	if !bytes.Equal(payload, p.Payload) {
+		t.Errorf("p.Payload must be same as payload.\n  payload: %+v,\np.Payload: %+v",
+			payload, p.Payload,
+		)
+	}
+
+	buf, err := p.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(rawPkt, buf) {
+		t.Errorf("buf must be same as rawPkt.\n   buf: %+v,\nrawPkt: %+v", buf, rawPkt)
+	}
+	if !bytes.Equal(rawPkt, p.Raw) {
+		t.Errorf("p.Raw must be same as rawPkt.\n p.Raw: %+v,\nrawPkt: %+v", p.Raw, rawPkt)
+	}
+	if !bytes.Equal(payload, p.Payload) {
+		t.Errorf("p.Payload must be same as payload.\n  payload: %+v,\np.Payload: %+v",
+			payload, p.Payload,
+		)
 	}
 }
 


### PR DESCRIPTION
#### Description

Head of `Packet.Raw` was wrong after `Packet.Marshal()`.

It was correct before:
https://github.com/pion/rtp/blame/541155ecd69be223914ccf274e9c968a17efc1f8/packet.go#L241

After #14, `Raw` points `Payload`:
https://github.com/pion/rtp/blame/master/packet.go#L267

#### Reference issue
Fixes #24
