### PR TITLE
Support Audio Level Indication

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Atsushi Watanabe](https://github.com/at-wat)
 * [adwpc](https://github.com/adwpc) *add transport-cc extension*
 * [Bao Nguyen](https://github.com/sysbot) *add VP9 noop, bug fixes.
+* [Tarrence van As](https://github.com/tarrencev) *add audio level extension*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/audiolevelextension.go
+++ b/audiolevelextension.go
@@ -1,0 +1,82 @@
+package rtp
+
+import (
+	"errors"
+)
+
+const (
+	// AudioLevelOneByteExtensionSize One byte header size
+	AudioLevelOneByteExtensionSize = 2
+	// AudioLevelTwoByteExtensionSize Two byte header size
+	AudioLevelTwoByteExtensionSize = 4
+)
+
+var (
+	errInvalidSize           = errors.New("invalid buffer size")
+	errInvalidExtensonLength = errors.New("invalid extension length")
+	errAudioLevelOverflow    = errors.New("audio level overflow")
+)
+
+// AudioLevelExtension is a extension payload format described in
+// https://tools.ietf.org/html/rfc6464
+//
+// Implementation based on:
+// https://chromium.googlesource.com/external/webrtc/+/e2a017725570ead5946a4ca8235af27470ca0df9/webrtc/modules/rtp_rtcp/source/rtp_header_extensions.cc#49
+//
+// One byte format:
+// 0                   1
+// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  ID   | len=0 |V| level       |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// Two byte format:
+// 0                   1                   2                   3
+// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |      ID       |     len=1     |V|    level    |    0 (pad)    |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type AudioLevelExtension struct {
+	ID    uint8
+	Level uint8
+	Voice bool
+}
+
+// Marshal serializes the members to buffer
+func (a *AudioLevelExtension) Marshal() ([]byte, error) {
+	if a.Level > 127 {
+		return nil, errAudioLevelOverflow
+	}
+	voice := uint8(0x00)
+	if a.Voice {
+		voice = 0x80
+	}
+	buf := make([]byte, AudioLevelOneByteExtensionSize)
+	buf[0] = a.ID << 4 & 0xf0
+	buf[1] = voice | a.Level
+	return buf, nil
+}
+
+// Unmarshal parses the passed byte slice and stores the result in the members
+func (a *AudioLevelExtension) Unmarshal(rawData []byte) error {
+	// one byte format
+	switch len(rawData) {
+	case AudioLevelOneByteExtensionSize:
+		if rawData[0]&^0xF0 != 0 {
+			return errInvalidExtensonLength
+		}
+		a.ID = rawData[0] >> 4
+		a.Level = rawData[1] & 0x7F
+		a.Voice = rawData[1]&0x80 != 0
+		return nil
+	case AudioLevelTwoByteExtensionSize:
+		if rawData[1] != 1 {
+			return errInvalidExtensonLength
+		}
+		a.ID = rawData[0]
+		a.Level = rawData[2] & 0x7F
+		a.Voice = rawData[2]&0x80 != 0
+		return nil
+	}
+	return errInvalidSize
+}

--- a/audiolevelextension_test.go
+++ b/audiolevelextension_test.go
@@ -1,0 +1,149 @@
+package rtp
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestAudioLevelExtensionTooSmall(t *testing.T) {
+	a := AudioLevelExtension{}
+
+	rawData := []byte{}
+
+	if err := a.Unmarshal(rawData); err != errInvalidSize {
+		t.Fatal("err != errInvalidSize")
+	}
+}
+
+func TestAudioLevelExtensionTooBig(t *testing.T) {
+	a := AudioLevelExtension{}
+
+	rawData := []byte{
+		0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	if err := a.Unmarshal(rawData); err != errInvalidSize {
+		t.Fatal("err != errInvalidSize")
+	}
+}
+
+func TestAudioLevelOneByteExtensionInvalidLength(t *testing.T) {
+	a := AudioLevelExtension{}
+
+	rawData := []byte{
+		0x31, 0x88,
+	}
+
+	if err := a.Unmarshal(rawData); err != errInvalidExtensonLength {
+		t.Fatal("err != errInvalidExtensonLength")
+	}
+}
+
+func TestAudioLevelTwoByteExtensionInvalidLength(t *testing.T) {
+	a := AudioLevelExtension{}
+
+	rawData := []byte{
+		0x30, 0x00, 0x00, 0x00,
+	}
+
+	if err := a.Unmarshal(rawData); err != errInvalidExtensonLength {
+		t.Fatal("err != errInvalidExtensonLength")
+	}
+}
+
+func TestAudioLevelOneByteExtensionVoiceTrue(t *testing.T) {
+	a1 := AudioLevelExtension{}
+
+	rawData := []byte{
+		0x30, 0x88,
+	}
+
+	if err := a1.Unmarshal(rawData); err != nil {
+		t.Fatal("Unmarshal error on extension data")
+	}
+
+	a2 := AudioLevelExtension{
+		ID:    3,
+		Level: 8,
+		Voice: true,
+	}
+
+	if a1 != a2 {
+		t.Error("Unmarshal failed")
+	}
+
+	dstData, _ := a2.Marshal()
+	if !bytes.Equal(dstData, rawData) {
+		t.Error("Marshal failed")
+	}
+}
+
+func TestAudioLevelOneByteExtensionVoiceFalse(t *testing.T) {
+	a1 := AudioLevelExtension{}
+
+	rawData := []byte{
+		0x30, 0x8,
+	}
+
+	if err := a1.Unmarshal(rawData); err != nil {
+		t.Fatal("Unmarshal error on extension data")
+	}
+
+	a2 := AudioLevelExtension{
+		ID:    3,
+		Level: 8,
+		Voice: false,
+	}
+
+	if a1 != a2 {
+		t.Error("Unmarshal failed")
+	}
+
+	dstData, _ := a2.Marshal()
+	if !bytes.Equal(dstData, rawData) {
+		t.Error("Marshal failed")
+	}
+}
+
+func TestAudioLevelOneByteExtensionLevelOverflow(t *testing.T) {
+	a := AudioLevelExtension{
+		ID:    3,
+		Level: 128,
+		Voice: false,
+	}
+
+	if _, err := a.Marshal(); err != errAudioLevelOverflow {
+		t.Fatal("err != errAudioLevelOverflow")
+	}
+}
+
+func TestAudioLevelTwoByteExtensionVoiceFalse(t *testing.T) {
+	a1 := AudioLevelExtension{}
+
+	oneByteRawData := []byte{
+		0x30, 0x8,
+	}
+
+	twoByteRawData := []byte{
+		0x3, 0x1, 0x8, 0x0,
+	}
+
+	if err := a1.Unmarshal(twoByteRawData); err != nil {
+		t.Fatal("Unmarshal error on extension data")
+	}
+
+	a2 := AudioLevelExtension{
+		ID:    3,
+		Level: 8,
+		Voice: false,
+	}
+
+	if a1 != a2 {
+		t.Error("Unmarshal failed")
+	}
+
+	dstData, _ := a2.Marshal()
+	if !bytes.Equal(dstData, oneByteRawData) {
+		t.Error("Marshal failed")
+	}
+}


### PR DESCRIPTION
Adds support for parsing the audio level extension header as described in https://tools.ietf.org/html/rfc6464.

Supports decoding both one and two byte formats but only encodes one byte. Let me know if we would like to support marshaling into two byte as well. In that case let me know what interface would make sense.

#54 

