### PR TITLE
Fix rtp header extensions marshaling/unmarshaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [adwpc](https://github.com/adwpc) *add transport-cc extension*
 * [Bao Nguyen](https://github.com/sysbot) *add VP9 noop, bug fixes.
 * [Tarrence van As](https://github.com/tarrencev) *add audio level extension*
+* [Simone Gotti](https://github.com/sgotti)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
#### Description

* The length in the RTP Header extension is the number of 32 bit words in the
  extensions. I.E. with rfc 8285 multiple extensions is the size of the all the
  extensions divided by 4.
* The extensions must be be padded to 32-bit boundaries.

* Fix the tests to have a correct raw packet.
* Add some more tests.

#### Reference issue
Fixes #57 
