### PR TITLE
Fix extension padding on MarshalTo to dirty buffer

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -301,7 +301,10 @@ func (h *Header) MarshalTo(buf []byte) (n int, err error) {
 		binary.BigEndian.PutUint16(buf[extHeaderPos+2:extHeaderPos+4], uint16(roundedExtSize/4))
 
 		// add padding to reach 4 bytes boundaries
-		n += roundedExtSize - extSize
+		for i := 0; i < roundedExtSize-extSize; i++ {
+			buf[n] = 0
+			n++
+		}
 	}
 
 	h.PayloadOffset = n


### PR DESCRIPTION
MarshalTo to non-zero buffer didn't clear padding bytes.
(regression from 4b1b5825)

### Reference issue
Ref #56 and #58 
