### PR TITLE
Fix AbsSendTime marshal/unmarshal in Packetizer

### DIFF
--- a/abssendtimeextension.go
+++ b/abssendtimeextension.go
@@ -5,26 +5,18 @@ import (
 )
 
 const (
-	absSendTimeExtensionSize = 4
+	absSendTimeExtensionSize = 3
 )
 
 // AbsSendTimeExtension is a extension payload format in
 // http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
-//  0 1 2 3 4 5 6 7
-// +-+-+-+-+-+-+-+-+
-// |  ID   |  len  |
-// +-+-+-+-+-+-+-+-+
-// per RFC 5285
-// Len is the number of bytes in the extension - 1.
 type AbsSendTimeExtension struct {
-	ID        uint8
 	Timestamp uint64
 }
 
 // Marshal serializes the members to buffer.
 func (t *AbsSendTimeExtension) Marshal() ([]byte, error) {
 	return []byte{
-		(t.ID << 4) | 2,
 		byte(t.Timestamp & 0xFF0000 >> 16),
 		byte(t.Timestamp & 0xFF00 >> 8),
 		byte(t.Timestamp & 0xFF),
@@ -36,8 +28,7 @@ func (t *AbsSendTimeExtension) Unmarshal(rawData []byte) error {
 	if len(rawData) < absSendTimeExtensionSize {
 		return errTooSmall
 	}
-	t.ID = rawData[0] >> 4
-	t.Timestamp = uint64(rawData[1])<<16 | uint64(rawData[2])<<8 | uint64(rawData[3])
+	t.Timestamp = uint64(rawData[0])<<16 | uint64(rawData[1])<<8 | uint64(rawData[2])
 	return nil
 }
 

--- a/abssendtimeextension_test.go
+++ b/abssendtimeextension_test.go
@@ -41,11 +41,9 @@ func TestNtpConversion(t *testing.T) {
 func TestAbsSendTimeExtension_Roundtrip(t *testing.T) {
 	tests := []AbsSendTimeExtension{
 		{
-			ID:        1,
 			Timestamp: 123456,
 		},
 		{
-			ID:        2,
 			Timestamp: 654321,
 		},
 	}
@@ -57,9 +55,6 @@ func TestAbsSendTimeExtension_Roundtrip(t *testing.T) {
 		var out AbsSendTimeExtension
 		if err = out.Unmarshal(b); err != nil {
 			t.Fatal(err)
-		}
-		if in.ID != out.ID {
-			t.Errorf("[%d] ID differs, expected: %d, got: %d", i, in.ID, out.ID)
 		}
 		if in.Timestamp != out.Timestamp {
 			t.Errorf("[%d] Timestamp differs, expected: %d, got: %d", i, in.Timestamp, out.Timestamp)
@@ -77,7 +72,7 @@ func TestAbsSendTimeExtension_Estimate(t *testing.T) {
 	}
 	for i, in := range tests {
 		inTime := toTime(in.sendNTP)
-		send := &AbsSendTimeExtension{0, in.sendNTP >> 14}
+		send := &AbsSendTimeExtension{in.sendNTP >> 14}
 		b, err := send.Marshal()
 		if err != nil {
 			t.Fatal(err)

--- a/packetizer.go
+++ b/packetizer.go
@@ -82,13 +82,12 @@ func (p *packetizer) Packetize(payload []byte, samples uint32) []*Packet {
 		t := toNtpTime(p.timegen()) >> 14
 		//apply http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
 		b, err := (&AbsSendTimeExtension{
-			ID:        uint8(p.extensionNumbers.AbsSendTime),
 			Timestamp: t,
 		}).Marshal()
 		if err != nil {
 			return nil // never happens
 		}
-		err = packets[len(packets)-1].SetExtension(0, b)
+		err = packets[len(packets)-1].SetExtension(uint8(p.extensionNumbers.AbsSendTime), b)
 		if err != nil {
 			return nil // never happens
 		}

--- a/packetizer_test.go
+++ b/packetizer_test.go
@@ -2,7 +2,9 @@ package rtp
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/pion/rtp/codecs"
 )
@@ -19,5 +21,49 @@ func TestPacketizer(t *testing.T) {
 			packetlengths += fmt.Sprintf("Packet %d length %d\n", i, len(packets[i].Payload))
 		}
 		t.Fatalf("Generated %d packets instead of 2\n%s", len(packets), packetlengths)
+	}
+}
+
+func TestPacketizer_AbsSendTime(t *testing.T) {
+	//use the G722 payloader here, because it's very simple and all 0s is valid G722 data.
+	pktizer := NewPacketizer(100, 98, 0x1234ABCD, &codecs.G722Payloader{}, NewFixedSequencer(1234), 90000)
+	pktizer.(*packetizer).Timestamp = 45678
+	pktizer.(*packetizer).timegen = func() time.Time {
+		return time.Date(1985, time.June, 23, 4, 0, 0, 0, time.FixedZone("UTC-5", -5*60*60))
+		// (0xa0c65b1000000000>>14) & 0xFFFFFF  = 0x400000
+	}
+	pktizer.EnableAbsSendTime(1)
+
+	payload := []byte{0x11, 0x12, 0x13, 0x14}
+	packets := pktizer.Packetize(payload, 2000)
+
+	expected := &Packet{
+		Header: Header{
+			Version:          2,
+			Padding:          false,
+			Extension:        true,
+			Marker:           true,
+			PayloadOffset:    0, // not set by Packetize() at now
+			PayloadType:      98,
+			SequenceNumber:   1234,
+			Timestamp:        45678,
+			SSRC:             0x1234ABCD,
+			CSRC:             nil,
+			ExtensionProfile: 0xBEDE,
+			Extensions: []Extension{
+				{
+					id:      1,
+					payload: []byte{0x40, 0, 0},
+				},
+			},
+		},
+		Payload: []byte{0x11, 0x12, 0x13, 0x14},
+	}
+
+	if len(packets) != 1 {
+		t.Fatalf("Generated %d packets instead of 1", len(packets))
+	}
+	if !reflect.DeepEqual(expected, packets[0]) {
+		t.Errorf("Packetize failed\nexpected: %v\n     got: %v", expected, packets[0])
 	}
 }


### PR DESCRIPTION
ID/len byte of AbsSendTime was duplicated
and ID of AbsSendTime extension was always unmarshalled as 0.
(regression from edd47ed5)

### Reference issue
Ref #56
