### PR TITLE
Fix packet size validation on unmarshal

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,8 @@
+package rtp
+
+import (
+	"errors"
+)
+
+var errHeaderSizeInsufficient = errors.New("RTP header size insufficient")
+var errHeaderSizeInsufficientForExtension = errors.New("RTP header size insufficient for extension")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pion/rtp
 
-go 1.12
+go 1.13


### PR DESCRIPTION
Avoid panic on parsing invalid packet.
(New test uses Go 1.13 error wrapping. It requires Go 1.13 or later.)

found during investigating #62