### PR TITLE
Removed the reference to VP8 header in the OpusPacket comment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Tarrence van As](https://github.com/tarrencev) *add audio level extension*
 * [Simone Gotti](https://github.com/sgotti)
 * [Guilherme Souza](https://github.com/gqgs)
+* [Rob Lofthouse](https://github.com/roblofthouse)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/codecs/opus_packet.go
+++ b/codecs/opus_packet.go
@@ -18,7 +18,7 @@ func (p *OpusPayloader) Payload(mtu int, payload []byte) [][]byte {
 	return [][]byte{out}
 }
 
-// OpusPacket represents the VP8 header that is stored in the payload of an RTP Packet
+// OpusPacket represents the Opus header that is stored in the payload of an RTP Packet
 type OpusPacket struct {
 	Payload []byte
 }


### PR DESCRIPTION
#### Description

Typo in a comment in the opus_packet.go that incorrectly referred to VP8.
