### PR TITLE
Add H264PartitionHeadChecker

### DIFF
--- a/codecs/h264_packet.go
+++ b/codecs/h264_packet.go
@@ -11,6 +11,7 @@ type H264Payloader struct{}
 const (
 	stapaNALUType = 24
 	fuaNALUType   = 28
+	fubNALUType   = 29
 
 	fuaHeaderSize       = 2
 	stapaHeaderSize     = 1
@@ -18,8 +19,8 @@ const (
 
 	naluTypeBitmask   = 0x1F
 	naluRefIdcBitmask = 0x60
-	fuaStartBitmask   = 0x80
-	fuaEndBitmask     = 0x40
+	fuStartBitmask    = 0x80
+	fuEndBitmask      = 0x40
 )
 
 func annexbNALUStartCode() []byte { return []byte{0x00, 0x00, 0x00, 0x01} }
@@ -206,7 +207,7 @@ func (p *H264Packet) Unmarshal(payload []byte) ([]byte, error) {
 
 		p.fuaBuffer = append(p.fuaBuffer, payload[fuaHeaderSize:]...)
 
-		if payload[1]&fuaEndBitmask != 0 {
+		if payload[1]&fuEndBitmask != 0 {
 			naluRefIdc := payload[0] & naluRefIdcBitmask
 			fragmentedNaluType := payload[1] & naluTypeBitmask
 
@@ -231,9 +232,9 @@ func (*H264PartitionHeadChecker) IsPartitionHead(packet []byte) bool {
 		return false
 	}
 
-	if packet[0]&naluTypeBitmask == fuaNALUType &&
-		packet[1]&fuaStartBitmask == 0 {
-		return false
+	if packet[0]&naluTypeBitmask == fuaNALUType ||
+		packet[0]&naluTypeBitmask == fubNALUType {
+		return packet[1]&fuStartBitmask != 0
 	}
 
 	return true

--- a/codecs/h264_packet.go
+++ b/codecs/h264_packet.go
@@ -18,6 +18,7 @@ const (
 
 	naluTypeBitmask   = 0x1F
 	naluRefIdcBitmask = 0x60
+	fuaStartBitmask   = 0x80
 	fuaEndBitmask     = 0x40
 )
 
@@ -219,4 +220,21 @@ func (p *H264Packet) Unmarshal(payload []byte) ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("%w: %d", errUnhandledNALUType, naluType)
+}
+
+// H264PartitionHeadChecker checks H264 partition head
+type H264PartitionHeadChecker struct{}
+
+// IsPartitionHead checks if this is the head of a packetized nalu stream.
+func (*H264PartitionHeadChecker) IsPartitionHead(packet []byte) bool {
+	if packet == nil || len(packet) < 2 {
+		return false
+	}
+
+	if packet[0]&naluTypeBitmask == fuaNALUType &&
+		packet[1]&fuaStartBitmask == 0 {
+		return false
+	}
+
+	return true
 }

--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -202,13 +202,23 @@ func TestH264PartitionHeadChecker_IsPartitionHead(t *testing.T) {
 		t.Fatal("stapa nalu must be a partition head")
 	}
 
-	fuaStartNalu := []byte{fuaNALUType, fuaStartBitmask}
+	fuaStartNalu := []byte{fuaNALUType, fuStartBitmask}
 	if h264PartitionHeadChecker.IsPartitionHead(fuaStartNalu) == false {
 		t.Fatal("fua start nalu must be a partition head")
 	}
 
-	fuaEndNalu := []byte{fuaNALUType, fuaEndBitmask}
+	fuaEndNalu := []byte{fuaNALUType, fuEndBitmask}
 	if h264PartitionHeadChecker.IsPartitionHead(fuaEndNalu) {
 		t.Fatal("fua end nalu must not be a partition head")
+	}
+
+	fubStartNalu := []byte{fubNALUType, fuStartBitmask}
+	if h264PartitionHeadChecker.IsPartitionHead(fubStartNalu) == false {
+		t.Fatal("fub start nalu must be a partition head")
+	}
+
+	fubEndNalu := []byte{fubNALUType, fuEndBitmask}
+	if h264PartitionHeadChecker.IsPartitionHead(fubEndNalu) {
+		t.Fatal("fub end nalu must not be a partition head")
 	}
 }

--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -179,3 +179,36 @@ func TestH264Packet_Unmarshal(t *testing.T) {
 		t.Fatal("Failed to unmarshal a single packet with multiple NALUs into avc stream")
 	}
 }
+
+func TestH264PartitionHeadChecker_IsPartitionHead(t *testing.T) {
+	h264PartitionHeadChecker := H264PartitionHeadChecker{}
+
+	if h264PartitionHeadChecker.IsPartitionHead(nil) {
+		t.Fatal("nil must not be a partition head")
+	}
+
+	emptyNalu := []byte{}
+	if h264PartitionHeadChecker.IsPartitionHead(emptyNalu) {
+		t.Fatal("empty nalu must not be a partition head")
+	}
+
+	singleNalu := []byte{1, 0}
+	if h264PartitionHeadChecker.IsPartitionHead(singleNalu) == false {
+		t.Fatal("single nalu must be a partition head")
+	}
+
+	stapaNalu := []byte{stapaNALUType, 0}
+	if h264PartitionHeadChecker.IsPartitionHead(stapaNalu) == false {
+		t.Fatal("stapa nalu must be a partition head")
+	}
+
+	fuaStartNalu := []byte{fuaNALUType, fuaStartBitmask}
+	if h264PartitionHeadChecker.IsPartitionHead(fuaStartNalu) == false {
+		t.Fatal("fua start nalu must be a partition head")
+	}
+
+	fuaEndNalu := []byte{fuaNALUType, fuaEndBitmask}
+	if h264PartitionHeadChecker.IsPartitionHead(fuaEndNalu) {
+		t.Fatal("fua end nalu must not be a partition head")
+	}
+}


### PR DESCRIPTION
#### Description

`H264` has no dedicated `PartitionHeadChecker`. This PR fixes that.

#### Reference issue

None.