### PR TITLE
Remove the IsDetectedFinalPacket method from Depacketizer

### DIFF
--- a/codecs/h264_packet.go
+++ b/codecs/h264_packet.go
@@ -165,12 +165,6 @@ func (p *H264Packet) doPackaging(nalu []byte) []byte {
 	return append(annexbNALUStartCode(), nalu...)
 }
 
-// IsDetectedFinalPacketInSequence returns true of the packet passed in has the
-// marker bit set indicated the end of a packet sequence
-func (p *H264Packet) IsDetectedFinalPacketInSequence(rtpPacketMarketBit bool) bool {
-	return rtpPacketMarketBit
-}
-
 // Unmarshal parses the passed byte slice and stores the result in the H264Packet this method is called upon
 func (p *H264Packet) Unmarshal(payload []byte) ([]byte, error) {
 	if payload == nil {

--- a/codecs/opus_packet.go
+++ b/codecs/opus_packet.go
@@ -19,12 +19,6 @@ type OpusPacket struct {
 	Payload []byte
 }
 
-// IsDetectedFinalPacketInSequence returns true as all opus packets are always
-// final in a sequence
-func (p *OpusPacket) IsDetectedFinalPacketInSequence(rtpPacketMarketBit bool) bool {
-	return true
-}
-
 // Unmarshal parses the passed byte slice and stores the result in the OpusPacket this method is called upon
 func (p *OpusPacket) Unmarshal(packet []byte) ([]byte, error) {
 	if packet == nil {

--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -112,12 +112,6 @@ type VP8Packet struct {
 	Payload []byte
 }
 
-// IsDetectedFinalPacketInSequence returns true of the packet passed in has the
-// marker bit set indicated the end of a packet sequence
-func (p *VP8Packet) IsDetectedFinalPacketInSequence(rtpPacketMarketBit bool) bool {
-	return rtpPacketMarketBit
-}
-
 // Unmarshal parses the passed byte slice and stores the result in the VP8Packet this method is called upon
 func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
 	if payload == nil {

--- a/codecs/vp9_packet.go
+++ b/codecs/vp9_packet.go
@@ -149,12 +149,6 @@ type VP9Packet struct {
 	Payload []byte
 }
 
-// IsDetectedFinalPacketInSequence returns true of the packet passed in has the
-// marker bit set indicated the end of a packet sequence
-func (p *VP9Packet) IsDetectedFinalPacketInSequence(rtpPacketMarketBit bool) bool {
-	return rtpPacketMarketBit
-}
-
 // Unmarshal parses the passed byte slice and stores the result in the VP9Packet this method is called upon
 func (p *VP9Packet) Unmarshal(packet []byte) ([]byte, error) {
 	if packet == nil {

--- a/depacketizer.go
+++ b/depacketizer.go
@@ -2,6 +2,5 @@ package rtp
 
 // Depacketizer depacketizes a RTP payload, removing any RTP specific data from the payload
 type Depacketizer interface {
-	IsDetectedFinalPacketInSequence(rtpPacketMarketBit bool) bool
 	Unmarshal(packet []byte) ([]byte, error)
 }

--- a/partitionheadchecker.go
+++ b/partitionheadchecker.go
@@ -1,6 +1,8 @@
 package rtp
 
 // PartitionHeadChecker is the interface that checks whether the packet is keyframe or not
+// This is essentially func([]byte) bool, but for compatibility reasons is
+// kept as an interface.  The analogous PartitionTailChecker is just a function.
 type PartitionHeadChecker interface {
 	IsPartitionHead([]byte) bool
 }


### PR DESCRIPTION
Not only does this break all code that attempts to implement
a depacketizer, it is just a very verbose and error-prone way
of saying

  if codec is video {
      return packet.Mark
  }
  return true

It is better to check the codec type at the calling site rather
than imposing a new method on all depacketisers, which causes
code duplication and is very difficult to check.

Fixes #139.
