### PR TITLE
Revert the polarity of EnablePictureID

### DIFF
--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -2,8 +2,8 @@ package codecs
 
 // VP8Payloader payloads VP8 packets
 type VP8Payloader struct {
-	EnablePictureID bool
-	pictureID       uint16
+	OmitPictureID bool
+	pictureID     uint16
 }
 
 const (
@@ -34,7 +34,7 @@ func (p *VP8Payloader) Payload(mtu int, payload []byte) [][]byte {
 	 */
 
 	usingHeaderSize := vp8HeaderSize
-	if p.EnablePictureID {
+	if !p.OmitPictureID {
 		switch {
 		case p.pictureID == 0:
 		case p.pictureID < 128:
@@ -65,7 +65,7 @@ func (p *VP8Payloader) Payload(mtu int, payload []byte) [][]byte {
 			out[0] = 0x10
 			first = false
 		}
-		if p.EnablePictureID {
+		if !p.OmitPictureID {
 			switch usingHeaderSize {
 			case vp8HeaderSize:
 			case vp8HeaderSize + 2:

--- a/codecs/vp8_packet_test.go
+++ b/codecs/vp8_packet_test.go
@@ -117,8 +117,10 @@ func TestVP8Payloader_Payload(t *testing.T) {
 		expected  [][][]byte
 	}{
 		"WithoutPictureID": {
-			payloader: VP8Payloader{},
-			mtu:       2,
+			payloader: VP8Payloader{
+				OmitPictureID: true,
+			},
+			mtu: 2,
 			payload: [][]byte{
 				{0x90, 0x90, 0x90},
 				{0x91, 0x91},
@@ -130,8 +132,7 @@ func TestVP8Payloader_Payload(t *testing.T) {
 		},
 		"WithPictureID_1byte": {
 			payloader: VP8Payloader{
-				EnablePictureID: true,
-				pictureID:       0x20,
+				pictureID: 0x20,
 			},
 			mtu: 5,
 			payload: [][]byte{
@@ -150,8 +151,7 @@ func TestVP8Payloader_Payload(t *testing.T) {
 		},
 		"WithPictureID_2bytes": {
 			payloader: VP8Payloader{
-				EnablePictureID: true,
-				pictureID:       0x120,
+				pictureID: 0x120,
 			},
 			mtu: 6,
 			payload: [][]byte{


### PR DESCRIPTION
Replace the EnablePictureID flag by OmitPictureID, which has the
opposite polarity.  This means that the zero value enables the
PictureID, which is the better default in most cases.

Related to https://github.com/pion/webrtc/pull/1875
