### PR TITLE
Fix unmarshal of packets with padding

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,7 +8,9 @@ aler9 <46489434+aler9@users.noreply.github.com>
 Antoine Baché <antoine.bache@epitech.eu>
 Antoine Baché <antoine@tenten.app>
 Atsushi Watanabe <atsushi.w@ieee.org>
+baiyufei <baiyufei@outlook.com>
 Bao Nguyen <bao@n4n.dev>
+boks1971 <raja.gobi@tutanota.com>
 debiandebiandebian <debiandebiandebiandebian@gmail.com>
 ffmiyo <leffmiyo@gmail.com>
 Guilherme <gqgs@protonmail.com>

--- a/packet.go
+++ b/packet.go
@@ -210,7 +210,14 @@ func (p *Packet) Unmarshal(buf []byte) error {
 	if err != nil {
 		return err
 	}
-	p.Payload = buf[n:]
+	end := len(buf)
+	if p.Header.Padding {
+		end -= int(buf[end-1])
+	}
+	if end < n {
+		return errTooSmall
+	}
+	p.Payload = buf[n:end]
 	return nil
 }
 


### PR DESCRIPTION
#### Description
WebRTC clients use padding only packets as probe
packets for bandwidth estimation. As padding was
not removed from the payload, downstream code
trying to parse padding as valid media payload
results in erroneous parsing

Testing:
--------
- Add unit tests for different padding scenarios.
- Check that ion-sfu does not try to parse padding only
packets as valid video payload.

#### Reference issue
Fixes #...
