### PR TITLE
Make Packet.MarshalTo() thread-safe

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -470,7 +470,6 @@ func (p Packet) Marshal() (buf []byte, err error) {
 
 // MarshalTo serializes the packet and writes to the buffer.
 func (p Packet) MarshalTo(buf []byte) (n int, err error) {
-	p.Header.Padding = p.PaddingSize != 0
 	n, err = p.Header.MarshalTo(buf)
 	if err != nil {
 		return 0, err

--- a/packet_test.go
+++ b/packet_test.go
@@ -251,6 +251,7 @@ func TestBasic(t *testing.T) {
 				}},
 			},
 			Version:        2,
+			Padding:        true,
 			PayloadType:    96,
 			SequenceNumber: 27023,
 			Timestamp:      3653407706,


### PR DESCRIPTION
#### Description

A Marshal function shouldn't change any property of the object that is being marshaled. Otherwise, Marshal() is non-thread safe
and can't be called by multiple goroutines in parallel.

PR #155 makes Packet.Marshal() set the Packet.Header.Padding bit when Packet.PaddingSize is non-zero; while this is preferable from the user point of view, it breaks thread safety.

This patch fixes the issue.
