### PR TITLE
 Remove pointer from constant functions

### DIFF
--- a/abssendtimeextension.go
+++ b/abssendtimeextension.go
@@ -15,7 +15,7 @@ type AbsSendTimeExtension struct {
 }
 
 // Marshal serializes the members to buffer.
-func (t *AbsSendTimeExtension) Marshal() ([]byte, error) {
+func (t AbsSendTimeExtension) Marshal() ([]byte, error) {
 	return []byte{
 		byte(t.Timestamp & 0xFF0000 >> 16),
 		byte(t.Timestamp & 0xFF00 >> 8),

--- a/audiolevelextension.go
+++ b/audiolevelextension.go
@@ -36,7 +36,7 @@ type AudioLevelExtension struct {
 }
 
 // Marshal serializes the members to buffer
-func (a *AudioLevelExtension) Marshal() ([]byte, error) {
+func (a AudioLevelExtension) Marshal() ([]byte, error) {
 	if a.Level > 127 {
 		return nil, errAudioLevelOverflow
 	}

--- a/header_extension.go
+++ b/header_extension.go
@@ -135,12 +135,12 @@ func (e *OneByteHeaderExtension) Unmarshal(buf []byte) (int, error) {
 }
 
 // Marshal returns the extension payload.
-func (e *OneByteHeaderExtension) Marshal() ([]byte, error) {
+func (e OneByteHeaderExtension) Marshal() ([]byte, error) {
 	return e.payload, nil
 }
 
 // MarshalTo writes the extension payload to the given buffer.
-func (e *OneByteHeaderExtension) MarshalTo(buf []byte) (int, error) {
+func (e OneByteHeaderExtension) MarshalTo(buf []byte) (int, error) {
 	size := e.MarshalSize()
 	if size > len(buf) {
 		return 0, io.ErrShortBuffer
@@ -149,7 +149,7 @@ func (e *OneByteHeaderExtension) MarshalTo(buf []byte) (int, error) {
 }
 
 // MarshalSize returns the size of the extension payload.
-func (e *OneByteHeaderExtension) MarshalSize() int {
+func (e OneByteHeaderExtension) MarshalSize() int {
 	return len(e.payload)
 }
 
@@ -266,12 +266,12 @@ func (e *TwoByteHeaderExtension) Unmarshal(buf []byte) (int, error) {
 }
 
 // Marshal returns the extension payload.
-func (e *TwoByteHeaderExtension) Marshal() ([]byte, error) {
+func (e TwoByteHeaderExtension) Marshal() ([]byte, error) {
 	return e.payload, nil
 }
 
 // MarshalTo marshals the extension to the given buffer.
-func (e *TwoByteHeaderExtension) MarshalTo(buf []byte) (int, error) {
+func (e TwoByteHeaderExtension) MarshalTo(buf []byte) (int, error) {
 	size := e.MarshalSize()
 	if size > len(buf) {
 		return 0, io.ErrShortBuffer
@@ -280,7 +280,7 @@ func (e *TwoByteHeaderExtension) MarshalTo(buf []byte) (int, error) {
 }
 
 // MarshalSize returns the size of the extension payload.
-func (e *TwoByteHeaderExtension) MarshalSize() int {
+func (e TwoByteHeaderExtension) MarshalSize() int {
 	return len(e.payload)
 }
 
@@ -331,12 +331,12 @@ func (e *RawExtension) Unmarshal(buf []byte) (int, error) {
 }
 
 // Marshal returns the raw extension payload.
-func (e *RawExtension) Marshal() ([]byte, error) {
+func (e RawExtension) Marshal() ([]byte, error) {
 	return e.payload, nil
 }
 
 // MarshalTo marshals the extension to the given buffer.
-func (e *RawExtension) MarshalTo(buf []byte) (int, error) {
+func (e RawExtension) MarshalTo(buf []byte) (int, error) {
 	size := e.MarshalSize()
 	if size > len(buf) {
 		return 0, io.ErrShortBuffer
@@ -345,6 +345,6 @@ func (e *RawExtension) MarshalTo(buf []byte) (int, error) {
 }
 
 // MarshalSize returns the size of the extension when marshaled.
-func (e *RawExtension) MarshalSize() int {
+func (e RawExtension) MarshalSize() int {
 	return len(e.payload)
 }

--- a/packet.go
+++ b/packet.go
@@ -224,7 +224,7 @@ func (p *Packet) Unmarshal(buf []byte) error {
 }
 
 // Marshal serializes the header into bytes.
-func (h *Header) Marshal() (buf []byte, err error) {
+func (h Header) Marshal() (buf []byte, err error) {
 	buf = make([]byte, h.MarshalSize())
 
 	n, err := h.MarshalTo(buf)
@@ -235,7 +235,7 @@ func (h *Header) Marshal() (buf []byte, err error) {
 }
 
 // MarshalTo serializes the header and writes to the buffer.
-func (h *Header) MarshalTo(buf []byte) (n int, err error) {
+func (h Header) MarshalTo(buf []byte) (n int, err error) {
 	/*
 	 *  0                   1                   2                   3
 	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -332,7 +332,7 @@ func (h *Header) MarshalTo(buf []byte) (n int, err error) {
 }
 
 // MarshalSize returns the size of the header once marshaled.
-func (h *Header) MarshalSize() int {
+func (h Header) MarshalSize() int {
 	// NOTE: Be careful to match the MarshalTo() method.
 	size := 12 + (len(h.CSRC) * csrcLength)
 
@@ -457,7 +457,7 @@ func (h *Header) DelExtension(id uint8) error {
 }
 
 // Marshal serializes the packet into bytes.
-func (p *Packet) Marshal() (buf []byte, err error) {
+func (p Packet) Marshal() (buf []byte, err error) {
 	buf = make([]byte, p.MarshalSize())
 
 	n, err := p.MarshalTo(buf)
@@ -469,7 +469,7 @@ func (p *Packet) Marshal() (buf []byte, err error) {
 }
 
 // MarshalTo serializes the packet and writes to the buffer.
-func (p *Packet) MarshalTo(buf []byte) (n int, err error) {
+func (p Packet) MarshalTo(buf []byte) (n int, err error) {
 	p.Header.Padding = p.PaddingSize != 0
 	n, err = p.Header.MarshalTo(buf)
 	if err != nil {
@@ -490,12 +490,12 @@ func (p *Packet) MarshalTo(buf []byte) (n int, err error) {
 }
 
 // MarshalSize returns the size of the packet once marshaled.
-func (p *Packet) MarshalSize() int {
+func (p Packet) MarshalSize() int {
 	return p.Header.MarshalSize() + len(p.Payload) + int(p.PaddingSize)
 }
 
 // Clone returns a deep copy of p.
-func (p *Packet) Clone() *Packet {
+func (p Packet) Clone() *Packet {
 	clone := &Packet{}
 	clone.Header = p.Header.Clone()
 	if p.Payload != nil {

--- a/transportccextension.go
+++ b/transportccextension.go
@@ -23,7 +23,7 @@ type TransportCCExtension struct {
 }
 
 // Marshal serializes the members to buffer
-func (t *TransportCCExtension) Marshal() ([]byte, error) {
+func (t TransportCCExtension) Marshal() ([]byte, error) {
 	buf := make([]byte, transportCCExtensionSize)
 	binary.BigEndian.PutUint16(buf[0:2], t.TransportSequence)
 	return buf, nil


### PR DESCRIPTION
#### Description

Marshal, MarshalTo, MarshalSize, Clone functions shouldn't have a pointer, since they're constant. This convention is used by pion/rtcp and the standard library, and prevents coding errors.
