### PR TITLE
Allow packetizer marshal / unmarshal to be consistent

### DIFF
--- a/packetizer.go
+++ b/packetizer.go
@@ -67,6 +67,7 @@ func (p *packetizer) Packetize(payload []byte, samples uint32) []*Packet {
 				SequenceNumber: p.Sequencer.NextSequenceNumber(),
 				Timestamp:      p.Timestamp, // Figure out how to do timestamps
 				SSRC:           p.SSRC,
+				CSRC:           []uint32{},
 			},
 			Payload: pp,
 		}

--- a/packetizer_test.go
+++ b/packetizer_test.go
@@ -47,7 +47,7 @@ func TestPacketizer_AbsSendTime(t *testing.T) {
 			SequenceNumber:   1234,
 			Timestamp:        45678,
 			SSRC:             0x1234ABCD,
-			CSRC:             nil,
+			CSRC:             []uint32{},
 			ExtensionProfile: 0xBEDE,
 			Extensions: []Extension{
 				{
@@ -64,5 +64,79 @@ func TestPacketizer_AbsSendTime(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, packets[0]) {
 		t.Errorf("Packetize failed\nexpected: %v\n     got: %v", expected, packets[0])
+	}
+}
+
+func TestPacketizer_Roundtrip(t *testing.T) {
+	multiplepayload := make([]byte, 128)
+	packetizer := NewPacketizer(100, 98, 0x1234ABCD, &codecs.G722Payloader{}, NewRandomSequencer())
+	packets := packetizer.Packetize(multiplepayload, 1000)
+
+	rawPkts := make([][]byte, 0, 1400)
+	for _, pkt := range packets {
+		raw, err := pkt.Marshal()
+		if err != nil {
+			t.Errorf("Packet Marshal failed: %v", err)
+		}
+
+		rawPkts = append(rawPkts, raw)
+	}
+
+	for ndx, raw := range rawPkts {
+		expectedPkt := packets[ndx]
+		pkt := &Packet{}
+
+		err := pkt.Unmarshal(raw)
+		if err != nil {
+			t.Errorf("Packet Unmarshal failed: %v", err)
+		}
+
+		if len(raw) != pkt.MarshalSize() {
+			t.Errorf("Packet sizes don't match, expected %d but got %d", len(raw), pkt.MarshalSize())
+		}
+		if expectedPkt.MarshalSize() != pkt.MarshalSize() {
+			t.Errorf("Packet marshal sizes don't match, expected %d but got %d", expectedPkt.MarshalSize(), pkt.MarshalSize())
+		}
+
+		if expectedPkt.Version != pkt.Version {
+			t.Errorf("Packet versions don't match, expected %d but got %d", expectedPkt.Version, pkt.Version)
+		}
+		if expectedPkt.Padding != pkt.Padding {
+			t.Errorf("Packet versions don't match, expected %t but got %t", expectedPkt.Padding, pkt.Padding)
+		}
+		if expectedPkt.Extension != pkt.Extension {
+			t.Errorf("Packet versions don't match, expected %v but got %v", expectedPkt.Extension, pkt.Extension)
+		}
+		if expectedPkt.Marker != pkt.Marker {
+			t.Errorf("Packet versions don't match, expected %v but got %v", expectedPkt.Marker, pkt.Marker)
+		}
+		if expectedPkt.PayloadType != pkt.PayloadType {
+			t.Errorf("Packet versions don't match, expected %d but got %d", expectedPkt.PayloadType, pkt.PayloadType)
+		}
+		if expectedPkt.SequenceNumber != pkt.SequenceNumber {
+			t.Errorf("Packet versions don't match, expected %d but got %d", expectedPkt.SequenceNumber, pkt.SequenceNumber)
+		}
+		if expectedPkt.Timestamp != pkt.Timestamp {
+			t.Errorf("Packet versions don't match, expected %d but got %d", expectedPkt.Timestamp, pkt.Timestamp)
+		}
+		if expectedPkt.SSRC != pkt.SSRC {
+			t.Errorf("Packet versions don't match, expected %d but got %d", expectedPkt.SSRC, pkt.SSRC)
+		}
+		if !reflect.DeepEqual(expectedPkt.CSRC, pkt.CSRC) {
+			t.Errorf("Packet versions don't match, expected %v but got %v", expectedPkt.CSRC, pkt.CSRC)
+		}
+		if expectedPkt.ExtensionProfile != pkt.ExtensionProfile {
+			t.Errorf("Packet versions don't match, expected %d but got %d", expectedPkt.ExtensionProfile, pkt.ExtensionProfile)
+		}
+		if !reflect.DeepEqual(expectedPkt.Extensions, pkt.Extensions) {
+			t.Errorf("Packet versions don't match, expected %v but got %v", expectedPkt.Extensions, pkt.Extensions)
+		}
+		if !reflect.DeepEqual(expectedPkt.Payload, pkt.Payload) {
+			t.Errorf("Packet versions don't match, expected %v but got %v", expectedPkt.Payload, pkt.Payload)
+		}
+
+		if !reflect.DeepEqual(expectedPkt, pkt) {
+			t.Errorf("Packets don't match, expected %v but got %v", expectedPkt, pkt)
+		}
 	}
 }


### PR DESCRIPTION
#### Description
Add a test to validate round tripping packets from Packetizer results in identical packets. In addition, initialize the CSRC so it matches in line with the suggestions in the issue comments.

#### Reference issue
Fixes #79 
