### PR TITLE
Improve unmarshal header

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -100,7 +100,7 @@ func (h *Header) Unmarshal(buf []byte) (n int, err error) { //nolint:gocognit
 	h.Padding = (buf[0] >> paddingShift & paddingMask) > 0
 	h.Extension = (buf[0] >> extensionShift & extensionMask) > 0
 	nCSRC := int(buf[0] & ccMask)
-	if cap(h.CSRC) < nCSRC || h.CSRC == nil {
+	if cap(h.CSRC) < nCSRC {
 		h.CSRC = make([]uint32, nCSRC)
 	} else {
 		h.CSRC = h.CSRC[:nCSRC]
@@ -124,9 +124,7 @@ func (h *Header) Unmarshal(buf []byte) (n int, err error) { //nolint:gocognit
 		h.CSRC[i] = binary.BigEndian.Uint32(buf[offset:])
 	}
 
-	if h.Extensions != nil {
-		h.Extensions = h.Extensions[:0]
-	}
+	h.Extensions = h.Extensions[:0]
 
 	if h.Extension {
 		if expected := n + 4; len(buf) < expected {
@@ -159,7 +157,7 @@ func (h *Header) Unmarshal(buf []byte) (n int, err error) { //nolint:gocognit
 				}
 
 				extid := buf[n] >> 4
-				payloadLen := int(buf[n]&^0xF0 + 1)
+				payloadLen := int(buf[n]&0x0F + 1)
 				n++
 
 				if extid == extensionIDReserved {

--- a/packet_test.go
+++ b/packet_test.go
@@ -36,7 +36,7 @@ func TestBasic(t *testing.T) {
 			SequenceNumber: 27023,
 			Timestamp:      3653407706,
 			SSRC:           476325762,
-			CSRC:           []uint32{},
+			CSRC:           nil,
 		},
 		Payload:     rawPkt[20:],
 		PaddingSize: 0,
@@ -87,7 +87,7 @@ func TestBasic(t *testing.T) {
 			SequenceNumber: 27023,
 			Timestamp:      3653407706,
 			SSRC:           476325762,
-			CSRC:           []uint32{},
+			CSRC:           nil,
 		},
 		Payload:     rawPkt[20:21],
 		PaddingSize: 4,
@@ -119,7 +119,7 @@ func TestBasic(t *testing.T) {
 			SequenceNumber: 27023,
 			Timestamp:      3653407706,
 			SSRC:           476325762,
-			CSRC:           []uint32{},
+			CSRC:           nil,
 		},
 		Payload:     []byte{},
 		PaddingSize: 5,
@@ -154,7 +154,7 @@ func TestBasic(t *testing.T) {
 			SequenceNumber: 27023,
 			Timestamp:      3653407706,
 			SSRC:           476325762,
-			CSRC:           []uint32{},
+			CSRC:           nil,
 		},
 		Payload:     []byte{},
 		PaddingSize: 0,
@@ -1480,6 +1480,42 @@ func BenchmarkUnmarshal(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			p := &Packet{}
 			if err := p.Unmarshal(rawPkt); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkUnmarshalHeader(b *testing.B) {
+
+	rawPkt := []byte{
+		0x90, 0xe0, 0x69, 0x8f, 0xd9, 0xc2, 0x93, 0xda,
+		0x1c, 0x64, 0x27, 0x82, 0xBE, 0xDE, 0x00, 0x01,
+		0x50, 0xAA, 0x00, 0x00, 0x98, 0x36, 0xbe, 0x88,
+	}
+	b.Run("NewStructWithoutCSRC", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h := &Header{}
+			if _, err := h.Unmarshal(rawPkt); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	rawPkt = []byte{
+		0x92, 0xe0, 0x69, 0x8f, 0xd9, 0xc2, 0x93, 0xda,
+		0x1c, 0x64, 0x27, 0x82, 0x00, 0x00, 0x11, 0x11,
+		0x00, 0x00, 0x22, 0x22, 0xBE, 0xDE, 0x00, 0x01,
+		0x50, 0xAA, 0x00, 0x00, 0x98, 0x36, 0xbe, 0x88,
+	}
+	b.Run("NewStructWithCSRC", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h := &Header{}
+			if _, err := h.Unmarshal(rawPkt); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/packetizer.go
+++ b/packetizer.go
@@ -67,7 +67,7 @@ func (p *packetizer) Packetize(payload []byte, samples uint32) []*Packet {
 				SequenceNumber: p.Sequencer.NextSequenceNumber(),
 				Timestamp:      p.Timestamp, // Figure out how to do timestamps
 				SSRC:           p.SSRC,
-				CSRC:           []uint32{},
+				CSRC:           nil,
 			},
 			Payload: pp,
 		}

--- a/packetizer_test.go
+++ b/packetizer_test.go
@@ -52,7 +52,7 @@ func TestPacketizer_AbsSendTime(t *testing.T) {
 			SequenceNumber:   1234,
 			Timestamp:        45678,
 			SSRC:             0x1234ABCD,
-			CSRC:             []uint32{},
+			CSRC:             nil,
 			ExtensionProfile: 0xBEDE,
 			Extensions: []Extension{
 				{


### PR DESCRIPTION
No need to alloc empty slice if CSRC=0
Extensions always reset to zero length when unmarshal

#### Description

#### Reference issue

