### PR TITLE
Fix parsing of VP8 packets with degenerate header

### DIFF
--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -127,12 +127,11 @@ func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
 
 	payloadLen := len(payload)
 
-	if payloadLen < 4 {
-		return nil, errShortPacket
-	}
-
 	payloadIndex := 0
 
+	if payloadIndex >= payloadLen {
+		return nil, errShortPacket
+	}
 	p.X = (payload[payloadIndex] & 0x80) >> 7
 	p.N = (payload[payloadIndex] & 0x20) >> 5
 	p.S = (payload[payloadIndex] & 0x10) >> 4
@@ -141,14 +140,25 @@ func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
 	payloadIndex++
 
 	if p.X == 1 {
+		if payloadIndex >= payloadLen {
+			return nil, errShortPacket
+		}
 		p.I = (payload[payloadIndex] & 0x80) >> 7
 		p.L = (payload[payloadIndex] & 0x40) >> 6
 		p.T = (payload[payloadIndex] & 0x20) >> 5
 		p.K = (payload[payloadIndex] & 0x10) >> 4
 		payloadIndex++
+	} else {
+		p.I = 0
+		p.L = 0
+		p.T = 0
+		p.K = 0
 	}
 
 	if p.I == 1 { // PID present?
+		if payloadIndex >= payloadLen {
+			return nil, errShortPacket
+		}
 		if payload[payloadIndex]&0x80 > 0 { // M == 1, PID is 16bit
 			p.PictureID = (uint16(payload[payloadIndex]&0x7F) << 8) | uint16(payload[payloadIndex+1])
 			payloadIndex += 2
@@ -156,35 +166,43 @@ func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
 			p.PictureID = uint16(payload[payloadIndex])
 			payloadIndex++
 		}
-	}
-
-	if payloadIndex >= payloadLen {
-		return nil, errShortPacket
+	} else {
+		p.PictureID = 0
 	}
 
 	if p.L == 1 {
+		if payloadIndex >= payloadLen {
+			return nil, errShortPacket
+		}
 		p.TL0PICIDX = payload[payloadIndex]
 		payloadIndex++
-	}
-
-	if payloadIndex >= payloadLen {
-		return nil, errShortPacket
+	} else {
+		p.TL0PICIDX = 0
 	}
 
 	if p.T == 1 || p.K == 1 {
+		if payloadIndex >= payloadLen {
+			return nil, errShortPacket
+		}
 		if p.T == 1 {
 			p.TID = payload[payloadIndex] >> 6
 			p.Y = (payload[payloadIndex] >> 5) & 0x1
+		} else {
+			p.TID = 0
+			p.Y = 0
 		}
 		if p.K == 1 {
 			p.KEYIDX = payload[payloadIndex] & 0x1F
+		} else {
+			p.KEYIDX = 0
 		}
 		payloadIndex++
+	} else {
+		p.TID = 0
+		p.Y = 0
+		p.KEYIDX = 0
 	}
 
-	if payloadIndex >= payloadLen {
-		return nil, errShortPacket
-	}
 	p.Payload = payload[payloadIndex:]
 	return p.Payload, nil
 }


### PR DESCRIPTION
Fix parsing of VP8 packets with degenerate header

All of the fields in the VP8 header except the first byte are
optional.  We used to reject VP8 packets smaller than 4 bytes,
which is incorrect.

There are two cases where such packets may appear on the wire.
GStreamer's WebRTC implementation generates VP8 streams with
no picture id, and one-byte headers.  It will occasionally
generate packets that are below 4 bytes, and which we used
to reject.

The second use case is more theoretical.  According to RFC 7741
Section 4.4, a packetizer may ignore VP8 partition boundaries.
If it splits a packet outside of a partition boundary, it may
generate a packet with S=0 and a one-byte header.
