### PR TITLE
fix the bug that caused `packet is not large enough: 1 <= 2` in the End of sequence NALU

### DIFF
--- a/codecs/h264_packet.go
+++ b/codecs/h264_packet.go
@@ -211,10 +211,8 @@ func (p *H264Packet) IsDetectedFinalPacketInSequence(rtpPacketMarketBit bool) bo
 
 // Unmarshal parses the passed byte slice and stores the result in the H264Packet this method is called upon
 func (p *H264Packet) Unmarshal(payload []byte) ([]byte, error) {
-	if payload == nil {
-		return nil, errNilPacket
-	} else if len(payload) <= 2 {
-		return nil, fmt.Errorf("%w: %d <= 2", errShortPacket, len(payload))
+	if len(payload) == 0 {
+		return nil, fmt.Errorf("%w: %d <=0", errShortPacket, len(payload))
 	}
 
 	// NALU Types

--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -115,8 +115,16 @@ func TestH264Packet_Unmarshal(t *testing.T) {
 		t.Fatal("Unmarshal did not fail on nil payload")
 	}
 
-	if _, err := pkt.Unmarshal([]byte{0x00, 0x00}); err == nil {
-		t.Fatal("Unmarshal accepted a packet that is too small for a payload and header")
+	if _, err := pkt.Unmarshal([]byte{}); err == nil {
+		t.Fatal("Unmarshal did not fail on []byte{}")
+	}
+
+	if _, err := pkt.Unmarshal([]byte{0xFC}); err == nil {
+		t.Fatal("Unmarshal accepted a FU-A packet that is too small for a payload and header")
+	}
+
+	if _, err := pkt.Unmarshal([]byte{0x0A}); err != nil {
+		t.Fatal("Unmarshaling end of sequence(NALU Type : 10) should succeed")
 	}
 
 	if _, err := pkt.Unmarshal([]byte{0xFF, 0x00, 0x00}); err == nil {


### PR DESCRIPTION
#### Description
When I Unmarshal(`codecs.H264Packet.Unmarshal`)  packets sent by `codecs.H264Payloader` , I get `packet is not large enough: 1 <= 2`.


- version: [v1.7.13](https://github.com/pion/rtp/releases/tag/v1.7.13)

#### Cause
I checked the packet and found that the H.264 NALU type was the End of sequence (NALU type:10).
I looked into the End of sequence and found that the size of that NALU is only the NALU header and the rbsp is empty.
Please see [hear 7.3.2.5. End of sequence RBSP syntax](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwj3_rPGu_b8AhWVHHAKHe_MCZgQFnoECAkQAQ&url=https%3A%2F%2Fwww.itu.int%2Frec%2Fdologin_pub.asp%3Flang%3De%26id%3DT-REC-H.264-201304-S!!PDF-E%26type%3Ditems&usg=AOvVaw35JIsiAjAhfgPFgHaI5DOk) for more information on the End of sequence.
<img width="860" alt="スクリーンショット 2023-02-04 23 15 40" src="https://user-images.githubusercontent.com/1884515/216804426-758a922d-5f42-4883-a292-3bdc8be11e64.png">

The Unmarshall makes an error if the size is less than 1, but the End of sequence has a size of 1.

#### Proposed Correction
Remove checks such as payload size less than 2.

Only FU-A explicitly accesses the second byte, which is not affected because a separate boundary value check is performed.

