### PR TITLE
fix compatibility with gofmt

### DIFF
--- a/codecs/av1_packet.go
+++ b/codecs/av1_packet.go
@@ -69,12 +69,12 @@ func (p *AV1Payloader) Payload(mtu uint16, payload []byte) (payloads [][]byte) {
 }
 
 // AV1Packet represents a depacketized AV1 RTP Packet
-//
-//  0 1 2 3 4 5 6 7
-// +-+-+-+-+-+-+-+-+
-// |Z|Y| W |N|-|-|-|
-// +-+-+-+-+-+-+-+-+
-//
+/*
+*  0 1 2 3 4 5 6 7
+* +-+-+-+-+-+-+-+-+
+* |Z|Y| W |N|-|-|-|
+* +-+-+-+-+-+-+-+-+
+**/
 // https://aomediacodec.github.io/av1-rtp-spec/#44-av1-aggregation-header
 type AV1Packet struct {
 	// Z: MUST be set to 1 if the first OBU element is an

--- a/codecs/h265_packet.go
+++ b/codecs/h265_packet.go
@@ -32,11 +32,13 @@ const (
 
 // H265NALUHeader is a H265 NAL Unit Header
 // https://datatracker.ietf.org/doc/html/rfc7798#section-1.1.4
-// +---------------+---------------+
-//  |0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |F|   Type    |  LayerID  | TID |
-//  +-------------+-----------------+
+/*
+* +---------------+---------------+
+* |0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |F|   Type    |  LayerID  | TID |
+* +-------------+-----------------+
+**/
 type H265NALUHeader uint16
 
 func newH265NALUHeader(highByte, lowByte uint8) H265NALUHeader {
@@ -95,18 +97,19 @@ func (h H265NALUHeader) IsPACIPacket() bool {
 //
 
 // H265SingleNALUnitPacket represents a NALU packet, containing exactly one NAL unit.
-//     0                   1                   2                   3
-//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |           PayloadHdr          |      DONL (conditional)       |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |                                                               |
-//   |                  NAL unit payload data                        |
-//   |                                                               |
-//   |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |                               :...OPTIONAL RTP padding        |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//
+/*
+*  0                   1                   2                   3
+*  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |           PayloadHdr          |      DONL (conditional)       |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                                                               |
+* |                  NAL unit payload data                        |
+* |                                                               |
+* |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                               :...OPTIONAL RTP padding        |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+**/
 // Reference: https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.1
 type H265SingleNALUnitPacket struct {
 	// payloadHeader is the header of the H265 packet.
@@ -184,19 +187,19 @@ func (p *H265SingleNALUnitPacket) isH265Packet() {}
 //
 
 // H265AggregationUnitFirst represent the First Aggregation Unit in an AP.
-//
-//    0                   1                   2                   3
-//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//                   :       DONL (conditional)      |   NALU size   |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |   NALU size   |                                               |
-//   +-+-+-+-+-+-+-+-+         NAL unit                              |
-//   |                                                               |
-//   |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |                               :
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//
+/*
+*  0                   1                   2                   3
+*  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* :       DONL (conditional)      |   NALU size   |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |   NALU size   |                                               |
+* +-+-+-+-+-+-+-+-+         NAL unit                              |
+* |                                                               |
+* |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                               :
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+**/
 // Reference: https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.2
 type H265AggregationUnitFirst struct {
 	donl        *uint16
@@ -222,18 +225,18 @@ func (u H265AggregationUnitFirst) NalUnit() []byte {
 }
 
 // H265AggregationUnit represent the an Aggregation Unit in an AP, which is not the first one.
-//
-//    0                   1                   2                   3
-//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//                   : DOND (cond)   |          NALU size            |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |                                                               |
-//   |                       NAL unit                                |
-//   |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |                               :
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//
+/*
+*  0                   1                   2                   3
+*  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* : DOND (cond)   |          NALU size            |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                                                               |
+* |                       NAL unit                                |
+* |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                               :
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+**/
 // Reference: https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.2
 type H265AggregationUnit struct {
 	dond        *uint8
@@ -259,18 +262,19 @@ func (u H265AggregationUnit) NalUnit() []byte {
 }
 
 // H265AggregationPacket represents an Aggregation packet.
-//   0                   1                   2                   3
-//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |    PayloadHdr (Type=48)       |                               |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
-//   |                                                               |
-//   |             two or more aggregation units                     |
-//   |                                                               |
-//   |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |                               :...OPTIONAL RTP padding        |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//
+/*
+*  0                   1                   2                   3
+*  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |    PayloadHdr (Type=48)       |                               |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+* |                                                               |
+* |             two or more aggregation units                     |
+* |                                                               |
+* |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                               :...OPTIONAL RTP padding        |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+**/
 // Reference: https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.2
 type H265AggregationPacket struct {
 	firstUnit  *H265AggregationUnitFirst
@@ -395,11 +399,13 @@ const (
 )
 
 // H265FragmentationUnitHeader is a H265 FU Header
-// +---------------+
-// |0|1|2|3|4|5|6|7|
-// +-+-+-+-+-+-+-+-+
-// |S|E|  FuType   |
-// +---------------+
+/*
+* +---------------+
+* |0|1|2|3|4|5|6|7|
+* +-+-+-+-+-+-+-+-+
+* |S|E|  FuType   |
+* +---------------+
+**/
 type H265FragmentationUnitHeader uint8
 
 // S represents the start of a fragmented NAL unit.
@@ -421,20 +427,20 @@ func (h H265FragmentationUnitHeader) FuType() uint8 {
 }
 
 // H265FragmentationUnitPacket represents a single Fragmentation Unit packet.
-//
-//  0                   1                   2                   3
-// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-// |    PayloadHdr (Type=49)       |   FU header   | DONL (cond)   |
-// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
-// | DONL (cond)   |                                               |
-// |-+-+-+-+-+-+-+-+                                               |
-// |                         FU payload                            |
-// |                                                               |
-// |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-// |                               :...OPTIONAL RTP padding        |
-// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//
+/*
+*  0                   1                   2                   3
+*  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |    PayloadHdr (Type=49)       |   FU header   | DONL (cond)   |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+* | DONL (cond)   |                                               |
+* |-+-+-+-+-+-+-+-+                                               |
+* |                         FU payload                            |
+* |                                                               |
+* |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                               :...OPTIONAL RTP padding        |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+**/
 // Reference: https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.3
 type H265FragmentationUnitPacket struct {
 	// payloadHeader is the header of the H265 packet.
@@ -521,22 +527,22 @@ func (p *H265FragmentationUnitPacket) isH265Packet() {}
 //
 
 // H265PACIPacket represents a single H265 PACI packet.
-//
-//  0                   1                   2                   3
-// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-// |    PayloadHdr (Type=50)       |A|   cType   | PHSsize |F0..2|Y|
-// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-// |        Payload Header Extension Structure (PHES)              |
-// |=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=|
-// |                                                               |
-// |                  PACI payload: NAL unit                       |
-// |                   . . .                                       |
-// |                                                               |
-// |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-// |                               :...OPTIONAL RTP padding        |
-// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//
+/*
+*  0                   1                   2                   3
+*  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |    PayloadHdr (Type=50)       |A|   cType   | PHSsize |F0..2|Y|
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |        Payload Header Extension Structure (PHES)              |
+* |=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=|
+* |                                                               |
+* |                  PACI payload: NAL unit                       |
+* |                   . . .                                       |
+* |                                                               |
+* |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+* |                               :...OPTIONAL RTP padding        |
+* +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+**/
 // Reference: https://datatracker.ietf.org/doc/html/rfc7798#section-4.4.4
 type H265PACIPacket struct {
 	// payloadHeader is the header of the H265 packet.

--- a/codecs/vp9_packet.go
+++ b/codecs/vp9_packet.go
@@ -206,16 +206,13 @@ func (p *VP9Packet) Unmarshal(packet []byte) ([]byte, error) {
 }
 
 // Picture ID:
-//
-//	+-+-+-+-+-+-+-+-+
-//
-// I:   |M| PICTURE ID  |   M:0 => picture id is 7 bits.
-//
-//	+-+-+-+-+-+-+-+-+   M:1 => picture id is 15 bits.
-//
-// M:   | EXTENDED PID  |
-//
-//	+-+-+-+-+-+-+-+-+
+/*
+*      +-+-+-+-+-+-+-+-+
+* I:   |M| PICTURE ID  |   M:0 => picture id is 7 bits.
+*      +-+-+-+-+-+-+-+-+   M:1 => picture id is 15 bits.
+* M:   | EXTENDED PID  |
+*      +-+-+-+-+-+-+-+-+
+**/
 func (p *VP9Packet) parsePictureID(packet []byte, pos int) (int, error) {
 	if len(packet) <= pos {
 		return pos, errShortPacket
@@ -247,12 +244,11 @@ func (p *VP9Packet) parseLayerInfo(packet []byte, pos int) (int, error) {
 }
 
 // Layer indices (flexible mode):
-//
-//	+-+-+-+-+-+-+-+-+
-//
-// L:   |  T  |U|  S  |D|
-//
-//	+-+-+-+-+-+-+-+-+
+/*
+*      +-+-+-+-+-+-+-+-+
+* L:   |  T  |U|  S  |D|
+*      +-+-+-+-+-+-+-+-+
+**/
 func (p *VP9Packet) parseLayerInfoCommon(packet []byte, pos int) (int, error) {
 	if len(packet) <= pos {
 		return pos, errShortPacket
@@ -272,14 +268,13 @@ func (p *VP9Packet) parseLayerInfoCommon(packet []byte, pos int) (int, error) {
 }
 
 // Layer indices (non-flexible mode):
-//
-//	+-+-+-+-+-+-+-+-+
-//
-// L:   |  T  |U|  S  |D|
-//
-//	+-+-+-+-+-+-+-+-+
-//	|   TL0PICIDX   |
-//	+-+-+-+-+-+-+-+-+
+/*
+*      +-+-+-+-+-+-+-+-+
+* L:   |  T  |U|  S  |D|
+*      +-+-+-+-+-+-+-+-+
+*      |   TL0PICIDX   |
+*      +-+-+-+-+-+-+-+-+
+**/
 func (p *VP9Packet) parseLayerInfoNonFlexibleMode(packet []byte, pos int) (int, error) {
 	if len(packet) <= pos {
 		return pos, errShortPacket
@@ -291,13 +286,12 @@ func (p *VP9Packet) parseLayerInfoNonFlexibleMode(packet []byte, pos int) (int, 
 }
 
 // Reference indices:
-//
-//	+-+-+-+-+-+-+-+-+                P=1,F=1: At least one reference index
-//
-// P,F: | P_DIFF      |N|  up to 3 times          has to be specified.
-//
-//	+-+-+-+-+-+-+-+-+                    N=1: An additional P_DIFF follows
-//	                                          current P_DIFF.
+/*
+*      +-+-+-+-+-+-+-+-+                P=1,F=1: At least one reference index
+* P,F: | P_DIFF      |N|  up to 3 times          has to be specified.
+*      +-+-+-+-+-+-+-+-+                    N=1: An additional P_DIFF follows
+*                                              current P_DIFF.
+**/
 func (p *VP9Packet) parseRefIndices(packet []byte, pos int) (int, error) {
 	for {
 		if len(packet) <= pos {
@@ -318,31 +312,25 @@ func (p *VP9Packet) parseRefIndices(packet []byte, pos int) (int, error) {
 }
 
 // Scalability structure (SS):
-//
-//	+-+-+-+-+-+-+-+-+
-//
-// V:   | N_S |Y|G|-|-|-|
-//
-//	+-+-+-+-+-+-+-+-+              -|
-//
-// Y:   |     WIDTH     | (OPTIONAL)    .
-//   - +               .
-//     |               | (OPTIONAL)    .
-//     +-+-+-+-+-+-+-+-+               . N_S + 1 times
-//     |     HEIGHT    | (OPTIONAL)    .
-//   - +               .
-//     |               | (OPTIONAL)    .
-//     +-+-+-+-+-+-+-+-+              -|
-//
-// G:   |      N_G      | (OPTIONAL)
-//
-//	+-+-+-+-+-+-+-+-+                           -|
-//
-// N_G: |  T  |U| R |-|-| (OPTIONAL)                 .
-//
-//	+-+-+-+-+-+-+-+-+              -|            . N_G times
-//	|    P_DIFF     | (OPTIONAL)    . R times    .
-//	+-+-+-+-+-+-+-+-+              -|           -|
+/*
+*      +-+-+-+-+-+-+-+-+
+* V:   | N_S |Y|G|-|-|-|
+*      +-+-+-+-+-+-+-+-+              -|
+* Y:   |     WIDTH     | (OPTIONAL)    .
+*      +               .
+*      |               | (OPTIONAL)    .
+*      +-+-+-+-+-+-+-+-+               . N_S + 1 times
+*      |     HEIGHT    | (OPTIONAL)    .
+*      +               .
+*      |               | (OPTIONAL)    .
+*      +-+-+-+-+-+-+-+-+              -|
+* G:   |      N_G      | (OPTIONAL)
+*      +-+-+-+-+-+-+-+-+                           -|
+* N_G: |  T  |U| R |-|-| (OPTIONAL)                 .
+*      +-+-+-+-+-+-+-+-+              -|            . N_G times
+*      |    P_DIFF     | (OPTIONAL)    . R times    .
+*      +-+-+-+-+-+-+-+-+              -|           -|
+**/
 func (p *VP9Packet) parseSSData(packet []byte, pos int) (int, error) {
 	if len(packet) <= pos {
 		return pos, errShortPacket


### PR DESCRIPTION
#### Description

This prevents `gofmt -w -s` from messing up existing code.

Text with multiple spaces is now wrapped in long comments (/* */), that are not affected by gofmt.