### PR TITLE
Fix race condition in Packet.MarshalTo()

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -484,7 +484,6 @@ func (p Packet) Marshal() (buf []byte, err error) {
 
 // MarshalTo serializes the packet and writes to the buffer.
 func (p *Packet) MarshalTo(buf []byte) (n int, err error) {
-	p.Header.Padding = p.PaddingSize != 0
 	n, err = p.Header.MarshalTo(buf)
 	if err != nil {
 		return 0, err

--- a/packet_test.go
+++ b/packet_test.go
@@ -254,6 +254,7 @@ func TestBasic(t *testing.T) {
 				}},
 			},
 			Version:        2,
+			Padding:        true,
 			PayloadType:    96,
 			SequenceNumber: 27023,
 			Timestamp:      3653407706,


### PR DESCRIPTION
#### Description

This was already fixed by #168 but got lost in #227. in SFUs, in order to distribute a packet to all clients, MarshalTo() is called in parallel by multiple routines, causing a race condition because the padding flag is dynamically set inside MarshalTo(). This is particular annoying when running automated tests. This PR fixes the issue by removing this write operation as discussed in #168.

