### PR TITLE
Combine OneByte and TwoByte extension parsing

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,6 +18,7 @@ Guilherme <gqgs@protonmail.com>
 Haiyang Wang <ocean2811@outlook.com>
 Hugo Arregui <hugo@decentraland.org>
 John Bradley <jrb@turrettech.com>
+Juho Nurminen <juhonurm@gmail.com>
 Juliusz Chroboczek <jch@irif.fr>
 kawaway <kawawa.y@gmail.com>
 Kazuyuki Honda <hakobera@gmail.com>
@@ -31,6 +32,7 @@ Raphael Derosso Pereira <raphaelpereira@gmail.com>
 Rob Lofthouse <ri.lofthouse@gmail.com>
 Robin Raymond <robin@goheadroom.com>
 Sean <sean@pion.ly>
+Sean <sean@siobud.com>
 Sean DuBois <duboisea@twitch.tv>
 Sean DuBois <seaduboi@amazon.com>
 Sean DuBois <sean@pion.ly>
@@ -40,6 +42,7 @@ Steffen Vogel <post@steffenvogel.de>
 Tarrence van As <tarrence13@gmail.com>
 wangzixiang <wangzixiang@onething.net>
 Woodrow Douglass <wdouglass@carnegierobotics.com>
+訾明华 <565209960@qq.com>
 
 # List of contributors not appearing in Git history
 

--- a/packet_test.go
+++ b/packet_test.go
@@ -1192,6 +1192,34 @@ func TestRFC8285TwoByteSetExtensionShouldErrorWhenPayloadTooLarge(t *testing.T) 
 	}
 }
 
+func TestRFC8285Padding(t *testing.T) {
+	header := &Header{}
+
+	for _, payload := range [][]byte{
+		{
+			0b00010000,                      // header.Extension = true
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SequenceNumber, Timestamp, SSRC
+			0xBE, 0xDE, // header.ExtensionProfile = extensionProfileOneByte
+			0, 1, // extensionLength
+			0, 0, 0, // padding
+			1, // extid
+		},
+		{
+			0b00010000,                      // header.Extension = true
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // SequenceNumber, Timestamp, SSRC
+			0x10, 0x00, // header.ExtensionProfile = extensionProfileOneByte
+			0, 1, // extensionLength
+			0, 0, 0, // padding
+			1, // extid
+		},
+	} {
+		_, err := header.Unmarshal(payload)
+		if !errors.Is(err, errHeaderSizeInsufficientForExtension) {
+			t.Fatal("Expected errHeaderSizeInsufficientForExtension")
+		}
+	}
+}
+
 func TestRFC3550SetExtensionShouldErrorWhenNonZero(t *testing.T) {
 	payload := []byte{
 		// Payload


### PR DESCRIPTION
Reduces duplicated logic and increase coverage. Missing tests for bounds check on Padding and Payload Sizes

Co-Authored-By: Juho Nurminen <juhonurm@gmail.com>