### PR TITLE
fix unmarshaling panic vp8

### DIFF
--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -123,7 +123,7 @@ type VP8Packet struct {
 }
 
 // Unmarshal parses the passed byte slice and stores the result in the VP8Packet this method is called upon
-func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
+func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) { //nolint: gocognit
 	if payload == nil {
 		return nil, errNilPacket
 	}
@@ -163,6 +163,9 @@ func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
 			return nil, errShortPacket
 		}
 		if payload[payloadIndex]&0x80 > 0 { // M == 1, PID is 16bit
+			if payloadIndex+1 >= payloadLen {
+				return nil, errShortPacket
+			}
 			p.PictureID = (uint16(payload[payloadIndex]&0x7F) << 8) | uint16(payload[payloadIndex+1])
 			payloadIndex += 2
 		} else {

--- a/codecs/vp8_packet_test.go
+++ b/codecs/vp8_packet_test.go
@@ -106,7 +106,7 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	// attention to partition boundaries.  In that case, it may
 	// produce packets with minimal headers.
 
-	// The next two have been witnessed in nature.
+	// The next three have been witnessed in nature.
 	_, err = pck.Unmarshal([]byte{0x00})
 	if err != nil {
 		t.Errorf("Empty packet with trivial header: %v", err)
@@ -114,6 +114,13 @@ func TestVP8Packet_Unmarshal(t *testing.T) {
 	_, err = pck.Unmarshal([]byte{0x00, 0x2a, 0x94})
 	if err != nil {
 		t.Errorf("Non-empty packet with trivial header: %v", err)
+	}
+	raw, err = pck.Unmarshal([]byte{0x81, 0x81, 0x94})
+	if raw != nil {
+		t.Fatal("Result should be nil in case of error")
+	}
+	if !errors.Is(err, errShortPacket) {
+		t.Fatal("Error should be:", errShortPacket)
 	}
 
 	// The following two were invented.


### PR DESCRIPTION
panic when unmarshal 0x81, 0x81, 0x94 panic: runtime error: index out of range [3] with length 3

