### PR TITLE
Fix crash in Vp8Packet.Unmarshal

### DIFF
--- a/codecs/vp8_packet.go
+++ b/codecs/vp8_packet.go
@@ -163,6 +163,9 @@ func (p *VP8Packet) Unmarshal(payload []byte) ([]byte, error) {
 			return nil, errShortPacket
 		}
 		if payload[payloadIndex]&0x80 > 0 { // M == 1, PID is 16bit
+			if payloadIndex + 1 >= payloadLen {
+				return nil, errShortPacket
+			}
 			p.PictureID = (uint16(payload[payloadIndex]&0x7F) << 8) | uint16(payload[payloadIndex+1])
 			payloadIndex += 2
 		} else {

--- a/codecs/vp8_packet_test.go
+++ b/codecs/vp8_packet_test.go
@@ -238,3 +238,8 @@ func TestVP8IsPartitionHead(t *testing.T) {
 		}
 	})
 }
+
+func TestVP8PIDOverflow(t *testing.T) {
+	var vp8 VP8Packet
+	_, _ = vp8.Unmarshal([]byte("\x80\x80\x80"))
+}


### PR DESCRIPTION
We used to crash if the I bit was set and the payload was
one byte short.
