### PR TITLE
AV1 samplebuilder support (WIP)

### DIFF
--- a/codecs/av1_packet.go
+++ b/codecs/av1_packet.go
@@ -134,6 +134,8 @@ type AV1Packet struct {
 	// Each AV1 RTP Packet is a collection of OBU Elements. Each OBU Element may be a full OBU, or just a fragment of one.
 	// AV1Frame provides the tools to construct a collection of OBUs from a collection of OBU Elements
 	OBUElements [][]byte
+
+	videoDepacketizer
 }
 
 // Unmarshal parses the passed byte slice and stores the result in the AV1Packet this method is called upon
@@ -185,4 +187,10 @@ func (p *AV1Packet) Unmarshal(payload []byte) ([]byte, error) {
 	}
 
 	return payload[1:], nil
+}
+
+func (p *AV1Packet) IsPartitionHead(payload []byte) bool {
+	// at this point, p.Unmarshal may not have been called yet.  Check
+	// manually for Z == 0 & N == 1.
+	return len(payload) > 0 && (payload[0] & 0x88) != 0x08
 }


### PR DESCRIPTION
- Make AV1Packet implement Depacketizer
- Implement AppendToSample for AV1Packet

An attempt to implement the required hooks for the samplebuilder
to work with AV1.  This approach is likely to be both faster and
simpler than the one in #238.

COMPLETELY UNTESTED, DO NOT COMMIT.
