### PR TITLE
fix timestamp for h264 packetize

### DIFF
--- a/packetizer.go
+++ b/packetizer.go
@@ -81,7 +81,9 @@ func (p *packetizer) Packetize(payload []byte, samples uint32) []*Packet {
 			Payload: pp,
 		}
 	}
-	p.Timestamp += samples
+	if len(packets) > 0 {
+		p.Timestamp += samples
+	}
 
 	if len(packets) != 0 && p.extensionNumbers.AbsSendTime != 0 {
 		sendTime := NewAbsSendTimeExtension(p.timegen())


### PR DESCRIPTION
fix timestamp not to increase in case of sps, pps

#### Description

I used h264 packetizer to packetize h264 NAL data. and I set the samples values to 3000. I pushed SPS, PPS, IDR in order into the function.

I expected an increase of 3000 compared to the previous timestamp, but it increated by 9000

#### Reference issue
nothing
