### PR TITLE
Fix parsing of G bit in VP9 scalability structure

### DIFF
--- a/codecs/vp9_packet.go
+++ b/codecs/vp9_packet.go
@@ -435,7 +435,7 @@ func (p *VP9Packet) parseSSData(packet []byte, pos int) (int, error) {
 
 	p.NS = packet[pos] >> 5
 	p.Y = packet[pos]&0x10 != 0
-	p.G = (packet[pos]>>1)&0x7 != 0
+	p.G = packet[pos]&0x8 != 0
 	pos++
 
 	NS := p.NS + 1

--- a/codecs/vp9_packet_test.go
+++ b/codecs/vp9_packet_test.go
@@ -193,15 +193,15 @@ func TestVP9Packet_Unmarshal(t *testing.T) {
 			err: errShortPacket,
 		},
 		"ScalabilityMissingNG": {
-			b:   []byte("b00200000000"),
+			b:   []byte("b00800000000"),
 			err: errShortPacket,
 		},
 		"ScalabilityMissingTemporalLayerIDs": {
-			b:   []byte("20B0"),
+			b:   []byte("20H0"),
 			err: errShortPacket,
 		},
 		"ScalabilityMissingReferenceIndices": {
-			b:   []byte("20B007"),
+			b:   []byte("20H007"),
 			err: errShortPacket,
 		},
 	}

--- a/codecs/vp9_packet_test.go
+++ b/codecs/vp9_packet_test.go
@@ -169,6 +169,25 @@ func TestVP9Packet_Unmarshal(t *testing.T) {
 				Payload: []byte{},
 			},
 		},
+		"ScalabilityStructureReserved": {
+			b: []byte{
+				0x0A,
+				(1 << 5) | (0 << 4) | (0 << 3) | (1 << 2) | (1 << 1) | 1, // NS:1 Y:0 G:0, reserved fields set to 1
+			},
+			pkt: VP9Packet{
+				B:       true,
+				V:       true,
+				NS:      1,
+				Y:       false,
+				G:       false,
+				NG:      0,
+				Payload: []byte{},
+			},
+		},
+		"ScalabilityStructure_ShortPacket0": {
+			b:   []byte{0x0A, 0x10},
+			err: errShortPacket,
+		},
 		"ScalabilityMissingWidth": {
 			b:   []byte("200"),
 			err: errShortPacket,


### PR DESCRIPTION
Previously it would erroneously look at some of the reserved fields.