### PR TITLE
Refactor H264Payloader to allow the deactivation of STAP-A packets. 

### DIFF
--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -303,3 +303,28 @@ func TestH264Payloader_Payload_SPS_and_PPS_handling(t *testing.T) {
 		t.Fatal("SPS and PPS aren't packed together")
 	}
 }
+
+func TestH264Payloader_Payload_SPS_and_PPS_handling_no_stapA(t *testing.T) {
+	pck := H264Payloader{}
+	pck.DisableStapA = true
+
+	expectedSps := []byte{0x07, 0x00, 0x01}
+	// The SPS is packed as a single NALU
+	res := pck.Payload(1500, expectedSps)
+	if len(res) != 1 {
+		t.Fatal("Generated payload should not be empty")
+	}
+	if !reflect.DeepEqual(res[0], expectedSps) {
+		t.Fatal("SPS has not been packed correctly")
+	}
+	// The PPS is packed as a single NALU
+	expectedPps := []byte{0x08, 0x02, 0x03}
+	res = pck.Payload(1500, expectedPps)
+	if len(res) != 1 {
+		t.Fatal("Generated payload should not be empty")
+	}
+
+	if !reflect.DeepEqual(res[0], expectedPps) {
+		t.Fatal("PPS has not been packed correctly")
+	}
+}


### PR DESCRIPTION
#### Description

This change adds a field* to disable the creation of `STAP-A` packets by the H264Payloader.

- As per current behaviour, `STAP-A` packets are created by default.
- If  the creation of `STAP-A` packets  is disabled, NALUs of type 7 (SPS) and type 8 (PPS) will be packed as Single NAL Units.

This change can be a step to support `packetization-mode=0` (single NALUs) in compliance with RFC6184.

#### Reference issue

This change is related to https://github.com/bluenviron/gortsplib/issues/585 

#### Context and use case

The use case motivating this change is to simulate a proprietary piece of hardware. This hardware shows limited RTP packetization capabilities as it does not generate `STAP-A` packets (only single NALUs and FUas). 

Thanks,