### PR TITLE
Finish AV1 Implementation

### DIFF
--- a/codecs/av1_depacketizer.go
+++ b/codecs/av1_depacketizer.go
@@ -35,10 +35,10 @@ func (d *AV1Depacketizer) Unmarshal(payload []byte) (buff []byte, err error) {
 	}
 
 	// |Z|Y| W |N|-|-|-|
-	obuZ := (0b10000000 & payload[0]) != 0     // Z
-	obuY := (0b01000000 & payload[0]) != 0     // Y
-	obuCount := (0b00110000 & payload[0]) >> 4 // W
-	obuN := (0b00001000 & payload[0]) != 0     // N
+	obuZ := (av1ZMask & payload[0]) != 0     // Z
+	obuY := (av1YMask & payload[0]) != 0     // Y
+	obuCount := (av1WMask & payload[0]) >> 4 // W
+	obuN := (av1NMask & payload[0]) != 0     // N
 	d.Z = obuZ
 	d.Y = obuY
 	d.N = obuN
@@ -120,10 +120,7 @@ func (d *AV1Depacketizer) Unmarshal(payload []byte) (buff []byte, err error) {
 		}
 
 		if len(obuBuffer) == 0 {
-			return nil, fmt.Errorf(
-				"%w: OBU size %d is 0",
-				errShortPacket, lengthField,
-			)
+			continue
 		}
 
 		obuHeader, err := obu.ParseOBUHeader(obuBuffer)
@@ -187,5 +184,5 @@ func (d *AV1Depacketizer) IsPartitionHead(payload []byte) bool {
 		return false
 	}
 
-	return (payload[0] & 0b10000000) == 0
+	return (payload[0] & av1ZMask) == 0
 }

--- a/codecs/av1_packet.go
+++ b/codecs/av1_packet.go
@@ -8,95 +8,277 @@ import (
 )
 
 const (
-	zMask     = byte(0b10000000)
-	zBitshift = 7
+	av1ZMask     = byte(0b10000000)
+	av1ZBitshift = 7
 
-	yMask     = byte(0b01000000)
-	yBitshift = 6
+	av1YMask     = byte(0b01000000)
+	av1YBitshift = 6
 
-	wMask     = byte(0b00110000)
-	wBitshift = 4
+	av1WMask     = byte(0b00110000)
+	av1WBitshift = 4
 
-	nMask     = byte(0b00001000)
-	nBitshift = 3
-
-	obuFrameTypeMask     = byte(0b01111000)
-	obuFrameTypeBitshift = 3
-
-	obuFameTypeSequenceHeader = 1
-
-	av1PayloaderHeadersize = 1
-
-	leb128Size = 1
+	av1NMask     = byte(0b00001000)
+	av1NBitshift = 3
 )
 
 // AV1Payloader payloads AV1 packets.
-type AV1Payloader struct {
-	sequenceHeader []byte
-}
+type AV1Payloader struct{}
 
-// Payload fragments a AV1 packet across one or more byte arrays.
-// See AV1Packet for description of AV1 Payload Header.
+// Payload implements AV1 RTP payloader.
+// Reads from a open_bitstream_unit (OBU) framing stream as defined in
+// 5.3. https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=39
+// Returns AV1 RTP packets https://aomediacodec.github.io/av1-rtp-spec/
+// The payload is fragmented into multiple packets, each packet is a valid AV1 RTP payload.
+// nolint:cyclop
 func (p *AV1Payloader) Payload(mtu uint16, payload []byte) (payloads [][]byte) {
-	payloadDataIndex := 0
-	payloadDataRemaining := len(payload)
-
-	// Payload Data and MTU is non-zero
-	if mtu <= 0 || payloadDataRemaining <= 0 {
+	// 2 is the minimum MTU for AV1 (aggregate header + 1 byte)
+	if mtu <= 1 || len(payload) == 0 {
 		return payloads
 	}
 
-	// Cache Sequence Header and packetize with next payload
-	frameType := (payload[0] & obuFrameTypeMask) >> obuFrameTypeBitshift
-	if frameType == obuFameTypeSequenceHeader {
-		p.sequenceHeader = payload
+	// We maximize the use of the W field in the AV1 aggregation header
+	// to minimize the need for explicit length fields for each OBU.
+	// To achieve this, we temporarily hold the OBU payload before adding it to a packet.
+	// Since we can't determine in advance whether the next OBU should be included in the same packet
+	// or start a new one, we also can't know ahead of time if an OBU is the last in the current packet.
+	var currentOBUPayload []byte
+	var currentPacketOBUHeader *obu.ExtensionHeader
+	obusInPacket := 0
+	newSequence := false
+	startWithNewPacket := false
 
-		return payloads
+	for offset := 0; offset < len(payload); {
+		obuHeader, err := obu.ParseOBUHeader(payload[offset:])
+		if err != nil {
+			break
+		}
+
+		offset += obuHeader.Size()
+		//  if ( obu_has_size_field ) {
+		//    obu_size leb128()
+		//  } else {
+		//    obu_size = sz - 1 - obu_extension_flag
+		//  }
+		var obuSize int
+		if obuHeader.HasSizeField {
+			obuSizeValue, n, err := obu.ReadLeb128(payload[offset:])
+			if err != nil {
+				break
+			}
+
+			offset += int(n)            //nolint:gosec // G115, leb128 size is a signle digit
+			obuSize = int(obuSizeValue) //nolint:gosec // G115, Leb128 is capped at 4 bytes
+		} else {
+			obuSize = len(payload) - offset
+		}
+
+		// Each RTP packet MUST NOT contain OBUs that belong to different temporal units.
+		// If a sequence header OBU is present in an RTP packet, then it SHOULD be the first OBU in the packet.
+		// https://aomediacodec.github.io/av1-rtp-spec/#5-packetization-rules
+		needNewPacket := obuHeader.Type == obu.OBUTemporalDelimiter || obuHeader.Type == obu.OBUSequenceHeader
+		// If more than one OBU contained in an RTP packet has an OBU extension header,
+		// then the values of the temporal_id and spatial_id MUST be the same in all such OBUs in the RTP packet.
+		if !needNewPacket && obuHeader.ExtensionHeader != nil && currentPacketOBUHeader != nil {
+			needNewPacket = obuHeader.ExtensionHeader.SpatialID != currentPacketOBUHeader.SpatialID ||
+				obuHeader.ExtensionHeader.TemporalID != currentPacketOBUHeader.TemporalID
+		}
+
+		if obuHeader.ExtensionHeader != nil {
+			currentPacketOBUHeader = obuHeader.ExtensionHeader
+		}
+
+		if obuSize > len(payload)-offset {
+			break
+		}
+
+		if len(currentOBUPayload) > 0 {
+			payloads, obusInPacket = p.appendOBUPayload(
+				payloads,
+				currentOBUPayload,
+				newSequence,
+				needNewPacket,
+				startWithNewPacket,
+				int(mtu),
+				obusInPacket,
+			)
+			currentOBUPayload = nil
+			startWithNewPacket = needNewPacket
+
+			if needNewPacket {
+				newSequence = false
+				currentPacketOBUHeader = nil
+			}
+		}
+
+		// The temporal delimiter OBU, if present, SHOULD be removed when transmitting,
+		// and MUST be ignored by receivers. Tile list OBUs are not supported.
+		// They SHOULD be removed when transmitted, and MUST be ignored by receivers.
+		// https://aomediacodec.github.io/av1-rtp-spec/#5-packetization-rules
+		if obuHeader.Type == obu.OBUTileList || obuHeader.Type == obu.OBUTemporalDelimiter {
+			offset += obuSize
+
+			continue
+		}
+
+		currentOBUPayload = make([]byte, obuSize+obuHeader.Size())
+		// The AV1 specification allows OBUs to have an optional size field called obu_size
+		// (also leb128 encoded), signaled by the obu_has_size_field flag in the OBU header.
+		// To minimize overhead, the obu_has_size_field flag SHOULD be set to zero in all OBUs.
+		// https://aomediacodec.github.io/av1-rtp-spec/#45-payload-structure
+		obuHeader.HasSizeField = false
+		copy(currentOBUPayload, obuHeader.Marshal())
+		//nolint:gosec // G115 we validate the size of the payload
+		copy(currentOBUPayload[obuHeader.Size():], payload[offset:offset+obuSize])
+		offset += obuSize
+		newSequence = obuHeader.Type == obu.OBUSequenceHeader
 	}
 
-	for payloadDataRemaining > 0 {
-		obuCount := byte(1)
-		metadataSize := av1PayloaderHeadersize
-		if len(p.sequenceHeader) != 0 {
-			obuCount++
-			metadataSize += leb128Size + len(p.sequenceHeader)
-		}
-
-		out := make([]byte, minInt(int(mtu), payloadDataRemaining+metadataSize))
-		outOffset := av1PayloaderHeadersize
-		out[0] = obuCount << wBitshift
-
-		if obuCount == 2 {
-			// This Payload contain the start of a Coded Video Sequence
-			out[0] ^= nMask
-
-			out[1] = byte(obu.EncodeLEB128(uint(len(p.sequenceHeader))))
-			copy(out[2:], p.sequenceHeader)
-
-			outOffset += leb128Size + len(p.sequenceHeader)
-
-			p.sequenceHeader = nil
-		}
-
-		outBufferRemaining := len(out) - outOffset
-		copy(out[outOffset:], payload[payloadDataIndex:payloadDataIndex+outBufferRemaining])
-		payloadDataRemaining -= outBufferRemaining
-		payloadDataIndex += outBufferRemaining
-
-		// Does this Fragment contain an OBU that started in a previous payload
-		if len(payloads) > 0 {
-			out[0] ^= zMask
-		}
-
-		// This OBU will be continued in next Payload
-		if payloadDataRemaining != 0 {
-			out[0] ^= yMask
-		}
-
-		payloads = append(payloads, out)
+	if len(currentOBUPayload) > 0 {
+		payloads, _ = p.appendOBUPayload(
+			payloads,
+			currentOBUPayload,
+			newSequence,
+			true,
+			startWithNewPacket,
+			int(mtu),
+			obusInPacket,
+		)
 	}
 
 	return payloads
+}
+
+//nolint:cyclop
+func (p *AV1Payloader) appendOBUPayload(
+	payloads [][]byte,
+	obuPayload []byte,
+	isNewVideoSequence, isLast, startWithNewPacket bool,
+	mtu, currentOBUCount int,
+) ([][]byte, int) {
+	currentPayload := len(payloads) - 1
+	freeSpace := 0
+	if currentPayload >= 0 {
+		freeSpace = mtu - len(payloads[currentPayload])
+	}
+
+	if currentPayload < 0 || freeSpace <= 0 || startWithNewPacket {
+		payload := make([]byte, 1, mtu)
+		if isNewVideoSequence {
+			payload[0] |= 1 << av1NBitshift
+		}
+
+		payloads = append(payloads, payload)
+		currentPayload = len(payloads) - 1
+		// MTU - aggregation header
+		freeSpace = mtu - 1
+		currentOBUCount = 0
+	}
+
+	remaining := len(obuPayload)
+	// How much to write to the current packet.
+	toWrite := remaining
+	if toWrite >= freeSpace {
+		toWrite = freeSpace
+	}
+
+	// W: two bit field that describes the number of OBU elements in the packet.
+	// This field MUST be set equal to 0 or equal to the number of OBU elements contained in the packet.
+	// If set to 0, each OBU element MUST be preceded by a length field. If not set to 0 (i.e., W = 1, 2 or 3)
+	// the last OBU element MUST NOT be preceded by a length field.
+	// https://aomediacodec.github.io/av1-rtp-spec/#44-av1-aggregation-header
+	shouldUseWField := (isLast || toWrite >= freeSpace) && currentOBUCount < 3
+	switch {
+	case shouldUseWField:
+		payloads[currentPayload][0] |= byte((currentOBUCount+1)<<av1WBitshift) & av1WMask
+		payloads[currentPayload] = append(payloads[currentPayload], obuPayload[:toWrite]...)
+		currentOBUCount = 0
+	case freeSpace >= 2:
+		// 2 bytes is the minimum size for OBUs with length field.
+		// [1 byte for the length field] [1 byte for the OBU]
+		//nolint:gosec // G115 false positive
+		toWrite = p.computeWriteSize(toWrite, freeSpace)
+		lengthField := obu.WriteToLeb128(uint(toWrite)) //nolint:gosec // G115 false positive
+		payloads[currentPayload] = append(payloads[currentPayload], lengthField...)
+		payloads[currentPayload] = append(payloads[currentPayload], obuPayload[:toWrite]...)
+		currentOBUCount++
+	default:
+		// If we can't fit any more OBUs in the current packet (only 1 byte left and W=0)
+		toWrite = 0
+	}
+
+	obuPayload = obuPayload[toWrite:]
+	remaining -= toWrite
+
+	// Handle fragments.
+	for remaining > 0 {
+		// New packet with empty aggregation header.
+		payload := make([]byte, 1, mtu)
+		payloads = append(payloads, payload)
+		currentPayload++
+
+		// Append the Y bit to the previous packet. And Z bit to the current packet.
+		// If we wrote some bytes to the previous packet.
+		// Handles an edge case where the previous packet has only one byte remaining,
+		// while the W field is not used. This results in insufficient space
+		// for a one-byte length field and a one-byte OBU.
+		// So we don't write anything to the initial packet.
+		if toWrite != 0 {
+			payloads[currentPayload-1][0] |= av1YMask
+			payloads[currentPayload][0] |= av1ZMask
+		}
+
+		toWrite = remaining
+		if toWrite >= mtu-1 { // MTU - aggregation header
+			toWrite = mtu - 1
+		}
+
+		// Last OBU in the current packet, Or this whole packet is a fragment.
+		if isLast || remaining >= mtu-1 {
+			payloads[currentPayload][0] |= 1 << av1WBitshift
+		} else {
+			toWrite = p.computeWriteSize(toWrite, mtu-1)
+			lengthField := obu.WriteToLeb128(uint(toWrite)) //nolint:gosec // G115 false positive
+			payloads[currentPayload] = append(payloads[currentPayload], lengthField...)
+		}
+
+		payloads[currentPayload] = append(payloads[currentPayload], obuPayload[:toWrite]...)
+		obuPayload = obuPayload[toWrite:]
+		remaining -= toWrite
+		currentOBUCount = 1
+	}
+
+	return payloads, currentOBUCount
+}
+
+// Measure the maximum write size for a payload with leb128 encoding added.
+func (p *AV1Payloader) computeWriteSize(wantToWrite, canWrite int) int {
+	leb128Size, isAtEge := p.leb128Size(wantToWrite)
+	if canWrite >= wantToWrite+leb128Size {
+		return wantToWrite
+	}
+
+	// Handle edge case where subtracting one from the leb128 size
+	// results in a smaller leb128 size that can fit in the remaining space.
+	if isAtEge && canWrite >= wantToWrite+leb128Size-1 {
+		return wantToWrite - 1
+	}
+
+	return wantToWrite - leb128Size
+}
+
+func (p *AV1Payloader) leb128Size(leb128 int) (size int, isAtEge bool) {
+	switch {
+	case leb128 >= 268435456: // 2^28
+		return 5, leb128 == 268435456
+	case leb128 >= 2097152: // 2^21
+		return 4, leb128 == 2097152
+	case leb128 >= 16384: // 2^14
+		return 3, leb128 == 16384
+	case leb128 >= 128: // 2^7
+		return 2, leb128 == 128
+	default:
+		return 1, false
+	}
 }
 
 // AV1Packet represents a depacketized AV1 RTP Packet
@@ -107,6 +289,7 @@ func (p *AV1Payloader) Payload(mtu uint16, payload []byte) (payloads [][]byte) {
 * +-+-+-+-+-+-+-+-+
 **/
 // https://aomediacodec.github.io/av1-rtp-spec/#44-av1-aggregation-header
+// Deprecated: Use AV1Depacketizer instead.
 type AV1Packet struct {
 	// Z: MUST be set to 1 if the first OBU element is an
 	//    OBU fragment that is a continuation of an OBU fragment
@@ -148,10 +331,10 @@ func (p *AV1Packet) Unmarshal(payload []byte) ([]byte, error) {
 		return nil, errShortPacket
 	}
 
-	p.Z = ((payload[0] & zMask) >> zBitshift) != 0
-	p.Y = ((payload[0] & yMask) >> yBitshift) != 0
-	p.N = ((payload[0] & nMask) >> nBitshift) != 0
-	p.W = (payload[0] & wMask) >> wBitshift
+	p.Z = ((payload[0] & av1ZMask) >> av1ZBitshift) != 0
+	p.Y = ((payload[0] & av1YMask) >> av1YBitshift) != 0
+	p.N = ((payload[0] & av1NMask) >> av1NBitshift) != 0
+	p.W = (payload[0] & av1WMask) >> av1WBitshift
 
 	if p.Z && p.N {
 		return nil, errIsKeyframeAndFragment


### PR DESCRIPTION
#### Description
1. Rewrite the AV1 Payloader according to the spec.
2. AV1 bitstream reader.
3. Tries to optimize the use of the W field as much as possible to reduce the size of the packet.
4. Added tests around edge cases.
5. Deprecate AV1Packet as it has no use, and too late to change.

Tested and works as intended. I'll update the examples in the WebRTC repo accordingly.
#### Reference issue
https://github.com/pion/webrtc/issues/3036
https://github.com/pion/webrtc/issues/2788
https://github.com/pion/rtp/issues/273
https://github.com/pion/webrtc/issues/2639