### PR TITLE
Dont include videoDepacketizer in VP1Packet

### DIFF
--- a/codecs/av1_packet.go
+++ b/codecs/av1_packet.go
@@ -136,7 +136,8 @@ type AV1Packet struct {
 	// AV1Frame provides the tools to construct a collection of OBUs from a collection of OBU Elements
 	OBUElements [][]byte
 
-	videoDepacketizer
+	// zeroAllocation prevents populating the OBUElements field
+	zeroAllocation bool
 }
 
 // Unmarshal parses the passed byte slice and stores the result in the AV1Packet this method is called upon.


### PR DESCRIPTION
Now that we have separated the Packet/Depacketizer roles for
the AV1 codec, there is no need to include the videoDepacketizer
mixin in AV1Packet.

Related to #291
