### PR TITLE
Fix nalu parsing for 3-byte & 4-byte start seqs

### DIFF
--- a/codecs/h264_packet_test.go
+++ b/codecs/h264_packet_test.go
@@ -12,6 +12,12 @@ func TestH264Payloader_Payload(t *testing.T) { //nolint:cyclop
 	pck := H264Payloader{}
 	smallpayload := []byte{0x90, 0x90, 0x90}
 	multiplepayload := []byte{0x00, 0x00, 0x01, 0x90, 0x00, 0x00, 0x01, 0x90}
+	mixednalupayload := []byte{
+		0x00, 0x00, 0x01, 0x90,
+		0x00, 0x00, 0x00, 0x01, 0x90,
+		0x00, 0x00, 0x01, 0x90,
+		0x00, 0x00, 0x00, 0x01, 0x90,
+	}
 
 	largepayload := []byte{
 		0x00, 0x00, 0x01, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -78,6 +84,17 @@ func TestH264Payloader_Payload(t *testing.T) { //nolint:cyclop
 	for i := 0; i < 2; i++ {
 		if len(res[i]) != 1 {
 			t.Fatalf("Payload %d of 2 is packed incorrectly", i+1)
+		}
+	}
+
+	// Multiple NALU in a single payload with 3-byte and 4-byte start sequences
+	res = pck.Payload(5, mixednalupayload)
+	if len(res) != 4 {
+		t.Fatal("4 nal units should be broken out", len(res), res)
+	}
+	for i := 0; i < 4; i++ {
+		if len(res[i]) != 1 {
+			t.Fatalf("Payload %d of 4 is packed incorrectly: %v", i+1, res[i])
 		}
 	}
 


### PR DESCRIPTION
#### Description
There is an issue in the current `emitNalu` function where the implementation can skip over 3-byte start sequences. 

The `emitNalu` function was changed in commit bfe92b9 which introduced this regression: https://github.com/pion/rtp/commit/bfe92b95ae6f7195e58eb777dc1d860e511216fb#diff-5eca440e933baa4c5491dcd9ccc7c1f4d807994e6c5b54c304228c34fcc3c963L40 

From analysis of the current `emitNalu` function,
https://github.com/pion/rtp/blob/ee5524bed13b5f257ae7083ba4923001b59dfa59/codecs/h264_packet.go#L45-L67
one can observe that NALUs with 3-byte start sequences may be skipped over if it is the first NALU, or if it is between two NALUs with 4-byte start sequences (in this case: at L52 `end != -1`)

This PR aims to resolve this issue by searching for 3-byte start sequences and accounting for 4-byte sequences afterward.
