### PR TITLE
Remove padding workaround from packetizer.GeneratePadding

### DIFF
--- a/packetizer.go
+++ b/packetizer.go
@@ -165,9 +165,6 @@ func (p *packetizer) GeneratePadding(samples uint32) []*Packet {
 	packets := make([]*Packet, samples)
 
 	for i := 0; i < int(samples); i++ {
-		pp := make([]byte, 255)
-		pp[254] = 255
-
 		packets[i] = &Packet{
 			Header: Header{
 				Version:        2,
@@ -179,8 +176,8 @@ func (p *packetizer) GeneratePadding(samples uint32) []*Packet {
 				Timestamp:      p.Timestamp, // Use latest timestamp
 				SSRC:           p.SSRC,
 				CSRC:           []uint32{},
+				PaddingSize:    255,
 			},
-			Payload: pp,
 		}
 	}
 

--- a/packetizer_test.go
+++ b/packetizer_test.go
@@ -112,6 +112,20 @@ func TestPacketizer_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestPacketizer_GeneratePadding(t *testing.T) {
+	pktizer := NewPacketizer(100, 98, 0x1234ABCD, &codecs.G722Payloader{}, NewFixedSequencer(1234), 90000)
+
+	packets := pktizer.GeneratePadding(5)
+
+	assert.Len(t, packets, 5, "Should generate exactly 5 padding packets")
+	for i, pkt := range packets {
+		assert.Equal(t, true, pkt.Header.Padding, "Packet %d should have Padding set to true", i)
+		assert.Equal(t, byte(255), pkt.Header.PaddingSize, "Packet %d should have PaddingSize set to 255", i)
+		assert.Equal(t, byte(0), pkt.PaddingSize, "Packet %d should have PaddingSize set to 0", i)
+		assert.Nil(t, pkt.Payload, "Packet %d should have no Payload", i)
+	}
+}
+
 func TestNewPacketizerWithOptions_DefaultValues(t *testing.T) {
 	pack := NewPacketizerWithOptions(100, &codecs.G722Payloader{}, NewRandomSequencer(), 90000)
 	p, ok := pack.(*packetizer)


### PR DESCRIPTION
This is last part of fixes for https://github.com/pion/webrtc/issues/2403 . It removes workaround from `packetizer.GeneratePadding` so `Test_TrackLocalStatic_Padding` in `pion/webrtc` can verify that bug is properly fixes. It also alternately sets `PaddingSize` field in `Packet` and `Header` to verify that both old and new fields works.