### PR TITLE
Do not panic on empty extensions

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -337,12 +337,16 @@ func (h Header) MarshalTo(buf []byte) (n int, err error) { //nolint:cyclop
 				n += copy(buf[n:], extension.payload)
 			}
 		default: // RFC3550 Extension
-			extlen := len(h.Extensions[0].payload)
-			if extlen%4 != 0 {
-				// the payload must be in 32-bit words.
-				return 0, io.ErrShortBuffer
+			// Zero length extension is valid per the RFC3550 spec
+			// https://www.rfc-editor.org/rfc/rfc3550#section-5.3.1
+			if len(h.Extensions) > 0 {
+				extlen := len(h.Extensions[0].payload)
+				if extlen%4 != 0 {
+					// the payload must be in 32-bit words.
+					return 0, io.ErrShortBuffer
+				}
+				n += copy(buf[n:], h.Extensions[0].payload)
 			}
-			n += copy(buf[n:], h.Extensions[0].payload)
 		}
 
 		// calculate extensions size and round to 4 bytes boundaries
@@ -382,7 +386,9 @@ func (h Header) MarshalSize() int {
 				extSize += 2 + len(extension.payload)
 			}
 		default:
-			extSize += len(h.Extensions[0].payload)
+			if len(h.Extensions) > 0 {
+				extSize += len(h.Extensions[0].payload)
+			}
 		}
 
 		// extensions size must have 4 bytes boundaries

--- a/packet_test.go
+++ b/packet_test.go
@@ -1428,3 +1428,24 @@ func BenchmarkUnmarshal(b *testing.B) {
 		}
 	})
 }
+
+// https://github.com/pion/rtp/issues/315
+func TestMarshalSizePanic(t *testing.T) {
+	hdr := &Header{
+		Extension: true,
+	}
+
+	assert.Equal(t, 16, hdr.MarshalSize())
+}
+
+// https://github.com/pion/rtp/issues/315
+func TestMarshalToPanic(t *testing.T) {
+	hdr := &Header{
+		Extension: true,
+	}
+
+	buf := make([]byte, 16)
+	n, err := hdr.MarshalTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 16, n)
+}


### PR DESCRIPTION

#### Description

Zero length extension is valid per the RFC3550 spec, This is a fix for panic on marshaling empty extensions.

#### Reference issue
Fixes #315