### PR TITLE
Fix off-by-one in TwoByteHeaderExtension.Set

### DIFF
--- a/header_extension.go
+++ b/header_extension.go
@@ -60,7 +60,7 @@ func (e *OneByteHeaderExtension) Set(id uint8, buf []byte) error {
 		n += payloadLen
 	}
 
-	if len(e.payload) == 0 && !bytes.HasPrefix(buf, []byte{0xBE, 0xDE}) {
+	if len(e.payload) == 0 && !bytes.HasPrefix(buf, []byte{0xBE, 0xDE, 0x00, 0x00}) {
 		e.payload = []byte{0xBE, 0xDE, 0x00, 0x00}
 	}
 
@@ -200,12 +200,17 @@ func (e *TwoByteHeaderExtension) Set(id uint8, buf []byte) error {
 		n++
 
 		if extid == id {
-			e.payload = append(e.payload[:n+2], append(buf, e.payload[n+2+payloadLen:]...)...)
+			e.payload = append(e.payload[:n], append(buf, e.payload[n+payloadLen:]...)...)
 
 			return nil
 		}
 		n += payloadLen
 	}
+
+	if len(e.payload) == 0 && !bytes.HasPrefix(buf, []byte{0x10, 0x00, 0x00, 0x00}) {
+		e.payload = []byte{0x10, 0x00, 0x00, 0x00}
+	}
+
 	e.payload = append(e.payload, id, uint8(len(buf))) // nolint: gosec // G115
 	e.payload = append(e.payload, buf...)
 	binary.BigEndian.PutUint16(e.payload[2:4], binary.BigEndian.Uint16(e.payload[2:4])+1)

--- a/header_extension_test.go
+++ b/header_extension_test.go
@@ -224,6 +224,22 @@ func TestHeaderExtension_RFC8285OneByteDelExtension(t *testing.T) {
 	assert.Error(t, ext.Del(1), "Should return error when deleting extension that doesnt exist")
 }
 
+func TestHeaderExtension_GetIds(t *testing.T) {
+	oneByteExt := &OneByteHeaderExtension{}
+
+	assert.NoError(t, oneByteExt.Set(1, []byte{0xBB}))
+	assert.NoError(t, oneByteExt.Set(3, []byte{0xAA}))
+	assert.NoError(t, oneByteExt.Set(5, []byte{0xFF}))
+	assert.Equal(t, oneByteExt.GetIDs(), []uint8{1, 3, 5})
+
+	twoByteExt := &TwoByteHeaderExtension{}
+
+	assert.NoError(t, twoByteExt.Set(1, []byte{0xBB}))
+	assert.NoError(t, twoByteExt.Set(3, []byte{0xAA}))
+	assert.NoError(t, twoByteExt.Set(5, []byte{0xFF}))
+	assert.Equal(t, twoByteExt.GetIDs(), []uint8{1, 3, 5})
+}
+
 func TestHeaderExtension_RFC8285TwoByteDelExtension(t *testing.T) {
 	ext := &TwoByteHeaderExtension{}
 
@@ -258,4 +274,22 @@ func TestHeaderExtension_RFC8285OneByteExtensionRewrite(t *testing.T) {
 	res, err = ext.Marshal()
 	assert.NoError(t, err)
 	assert.Equal(t, res, []byte{0xBE, 0xDE, 0x00, 0x02, 0x12, 0x04, 0x05, 0x06, 0x32, 0x07, 0x08, 0x09})
+}
+
+func TestHeaderExtension_RFC8285TwoByteExtensionRewrite(t *testing.T) {
+	ext := &TwoByteHeaderExtension{}
+	assert.NoError(t, ext.Set(200, []byte{0x01, 0x02, 0x03}))
+	res, err := ext.Marshal()
+	assert.NoError(t, err)
+	assert.Equal(t, res, []byte{0x10, 0x00, 0x00, 0x01, 0xc8, 0x03, 0x01, 0x02, 0x03})
+
+	assert.NoError(t, ext.Set(200, []byte{0x04, 0x05, 0x06}))
+	res, err = ext.Marshal()
+	assert.NoError(t, err)
+	assert.Equal(t, res, []byte{0x10, 0x00, 0x00, 0x01, 0xc8, 0x03, 0x04, 0x05, 0x06})
+
+	assert.NoError(t, ext.Set(50, []byte{0x07, 0x08, 0x09}))
+	res, err = ext.Marshal()
+	assert.NoError(t, err)
+	assert.Equal(t, res, []byte{0x10, 0x00, 0x00, 0x02, 0xc8, 0x03, 0x04, 0x05, 0x06, 0x32, 0x03, 0x07, 0x08, 0x09})
 }


### PR DESCRIPTION
Also add a unit test to assert behavior

Relates to #288