### PR TITLE
Add MarshalTo for zero-allocation extension marshalling

### DIFF
--- a/abscapturetimeextension_test.go
+++ b/abscapturetimeextension_test.go
@@ -59,3 +59,23 @@ func TestAbsCaptureTimeExtension_Roundtrip(t *testing.T) { //nolint:cyclop
 		assert.Equal(t, -250*time.Millisecond, *o2.EstimatedCaptureClockOffsetDuration())
 	})
 }
+
+var absCaptureTimeSink []byte
+
+func BenchmarkAbsCaptureTimeExtension_Marshal(b *testing.B) {
+	ext := NewAbsCaptureTimeExtension(time.Now())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		absCaptureTimeSink, _ = ext.Marshal()
+	}
+}
+
+func BenchmarkAbsCaptureTimeExtensionWithOffset_Marshal(b *testing.B) {
+	ext := NewAbsCaptureTimeExtensionWithCaptureClockOffset(time.Now(), 100*time.Millisecond)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		absCaptureTimeSink, _ = ext.Marshal()
+	}
+}

--- a/abscapturetimeextension_test.go
+++ b/abscapturetimeextension_test.go
@@ -4,6 +4,7 @@
 package rtp
 
 import (
+	"io"
 	"testing"
 	"time"
 
@@ -60,7 +61,45 @@ func TestAbsCaptureTimeExtension_Roundtrip(t *testing.T) { //nolint:cyclop
 	})
 }
 
-var absCaptureTimeSink []byte
+func TestAbsCaptureTimeExtensionMarshalTo(t *testing.T) {
+	t.Run("without offset", func(t *testing.T) {
+		ext := NewAbsCaptureTimeExtension(time.Now())
+
+		buf := make([]byte, ext.MarshalSize())
+		n, err := ext.MarshalTo(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, ext.MarshalSize(), n)
+
+		expected, _ := ext.Marshal()
+		assert.Equal(t, expected, buf)
+
+		_, err = ext.MarshalTo(nil)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+	})
+
+	t.Run("with offset", func(t *testing.T) {
+		ext := NewAbsCaptureTimeExtensionWithCaptureClockOffset(time.Now(), 100*time.Millisecond)
+
+		buf := make([]byte, ext.MarshalSize())
+		n, err := ext.MarshalTo(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, ext.MarshalSize(), n)
+
+		expected, _ := ext.Marshal()
+		assert.Equal(t, expected, buf)
+
+		_, err = ext.MarshalTo(nil)
+		assert.ErrorIs(t, err, io.ErrShortBuffer)
+	})
+}
+
+//nolint:gochecknoglobals
+var (
+	absCaptureTimeSink        []byte
+	absCaptureTimeBuf         = make([]byte, absCaptureTimeExtensionSize)
+	absCaptureTimeExtendedBuf = make([]byte, absCaptureTimeExtendedExtensionSize)
+	absCaptureTimeSinkInt     int
+)
 
 func BenchmarkAbsCaptureTimeExtension_Marshal(b *testing.B) {
 	ext := NewAbsCaptureTimeExtension(time.Now())
@@ -71,11 +110,29 @@ func BenchmarkAbsCaptureTimeExtension_Marshal(b *testing.B) {
 	}
 }
 
+func BenchmarkAbsCaptureTimeExtension_MarshalTo(b *testing.B) {
+	ext := NewAbsCaptureTimeExtension(time.Now())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		absCaptureTimeSinkInt, _ = ext.MarshalTo(absCaptureTimeBuf)
+	}
+}
+
 func BenchmarkAbsCaptureTimeExtensionWithOffset_Marshal(b *testing.B) {
 	ext := NewAbsCaptureTimeExtensionWithCaptureClockOffset(time.Now(), 100*time.Millisecond)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		absCaptureTimeSink, _ = ext.Marshal()
+	}
+}
+
+func BenchmarkAbsCaptureTimeExtensionWithOffset_MarshalTo(b *testing.B) {
+	ext := NewAbsCaptureTimeExtensionWithCaptureClockOffset(time.Now(), 100*time.Millisecond)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		absCaptureTimeSinkInt, _ = ext.MarshalTo(absCaptureTimeExtendedBuf)
 	}
 }

--- a/abssendtimeextension.go
+++ b/abssendtimeextension.go
@@ -4,6 +4,7 @@
 package rtp
 
 import (
+	"io"
 	"time"
 )
 
@@ -15,6 +16,24 @@ const (
 // http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
 type AbsSendTimeExtension struct {
 	Timestamp uint64
+}
+
+// MarshalSize returns the size of the AbsSendTimeExtension once marshaled.
+func (t AbsSendTimeExtension) MarshalSize() int {
+	return absSendTimeExtensionSize
+}
+
+// MarshalTo marshals the extension to the given buffer.
+// Returns io.ErrShortBuffer if buf is too small.
+func (t AbsSendTimeExtension) MarshalTo(buf []byte) (int, error) {
+	if len(buf) < absSendTimeExtensionSize {
+		return 0, io.ErrShortBuffer
+	}
+	buf[0] = byte(t.Timestamp & 0xFF0000 >> 16)
+	buf[1] = byte(t.Timestamp & 0xFF00 >> 8)
+	buf[2] = byte(t.Timestamp & 0xFF)
+
+	return absSendTimeExtensionSize, nil
 }
 
 // Marshal serializes the members to buffer.

--- a/abssendtimeextension_test.go
+++ b/abssendtimeextension_test.go
@@ -97,3 +97,14 @@ func TestAbsSendTimeExtension_Estimate(t *testing.T) {
 		)
 	}
 }
+
+var absSendTimeSink []byte
+
+func BenchmarkAbsSendTimeExtension_Marshal(b *testing.B) {
+	ext := AbsSendTimeExtension{Timestamp: 123456}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		absSendTimeSink, _ = ext.Marshal()
+	}
+}

--- a/abssendtimeextension_test.go
+++ b/abssendtimeextension_test.go
@@ -4,6 +4,7 @@
 package rtp
 
 import (
+	"io"
 	"testing"
 	"time"
 
@@ -98,7 +99,27 @@ func TestAbsSendTimeExtension_Estimate(t *testing.T) {
 	}
 }
 
-var absSendTimeSink []byte
+func TestAbsSendTimeExtensionMarshalTo(t *testing.T) {
+	ext := AbsSendTimeExtension{Timestamp: 123456}
+
+	buf := make([]byte, ext.MarshalSize())
+	n, err := ext.MarshalTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, ext.MarshalSize(), n)
+
+	expected, _ := ext.Marshal()
+	assert.Equal(t, expected, buf)
+
+	_, err = ext.MarshalTo(nil)
+	assert.ErrorIs(t, err, io.ErrShortBuffer)
+}
+
+//nolint:gochecknoglobals
+var (
+	absSendTimeSink    []byte
+	absSendTimeBuf     = make([]byte, absSendTimeExtensionSize)
+	absSendTimeSinkInt int
+)
 
 func BenchmarkAbsSendTimeExtension_Marshal(b *testing.B) {
 	ext := AbsSendTimeExtension{Timestamp: 123456}
@@ -106,5 +127,14 @@ func BenchmarkAbsSendTimeExtension_Marshal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		absSendTimeSink, _ = ext.Marshal()
+	}
+}
+
+func BenchmarkAbsSendTimeExtension_MarshalTo(b *testing.B) {
+	ext := AbsSendTimeExtension{Timestamp: 123456}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		absSendTimeSinkInt, _ = ext.MarshalTo(absSendTimeBuf)
 	}
 }

--- a/audiolevelextension_test.go
+++ b/audiolevelextension_test.go
@@ -4,6 +4,7 @@
 package rtp
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,9 +58,32 @@ func TestAudioLevelExtensionLevelOverflow(t *testing.T) {
 
 	_, err := a.Marshal()
 	assert.ErrorIs(t, err, errAudioLevelOverflow)
+
+	_, err = a.MarshalTo(make([]byte, 10))
+	assert.ErrorIs(t, err, errAudioLevelOverflow)
 }
 
-var audioLevelSink []byte
+func TestAudioLevelExtensionMarshalTo(t *testing.T) {
+	a := AudioLevelExtension{Level: 8, Voice: true}
+
+	buf := make([]byte, a.MarshalSize())
+	n, err := a.MarshalTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, a.MarshalSize(), n)
+
+	expected, _ := a.Marshal()
+	assert.Equal(t, expected, buf)
+
+	_, err = a.MarshalTo(nil)
+	assert.ErrorIs(t, err, io.ErrShortBuffer)
+}
+
+//nolint:gochecknoglobals
+var (
+	audioLevelSink    []byte
+	audioLevelBuf     = make([]byte, audioLevelExtensionSize)
+	audioLevelSinkInt int
+)
 
 func BenchmarkAudioLevelExtension_Marshal(b *testing.B) {
 	ext := AudioLevelExtension{Level: 8, Voice: true}
@@ -67,5 +91,14 @@ func BenchmarkAudioLevelExtension_Marshal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		audioLevelSink, _ = ext.Marshal()
+	}
+}
+
+func BenchmarkAudioLevelExtension_MarshalTo(b *testing.B) {
+	ext := AudioLevelExtension{Level: 8, Voice: true}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		audioLevelSinkInt, _ = ext.MarshalTo(audioLevelBuf)
 	}
 }

--- a/audiolevelextension_test.go
+++ b/audiolevelextension_test.go
@@ -58,3 +58,14 @@ func TestAudioLevelExtensionLevelOverflow(t *testing.T) {
 	_, err := a.Marshal()
 	assert.ErrorIs(t, err, errAudioLevelOverflow)
 }
+
+var audioLevelSink []byte
+
+func BenchmarkAudioLevelExtension_Marshal(b *testing.B) {
+	ext := AudioLevelExtension{Level: 8, Voice: true}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		audioLevelSink, _ = ext.Marshal()
+	}
+}

--- a/codecs/av1/obu/leb128.go
+++ b/codecs/av1/obu/leb128.go
@@ -84,26 +84,3 @@ func WriteToLeb128(in uint) []byte {
 	return b // unreachable
 }
 
-// Leb128Size returns the number of bytes needed to encode a value as LEB128.
-func Leb128Size(in uint) int {
-	size := 1
-	for in >>= 7; in != 0; in >>= 7 {
-		size++
-	}
-
-	return size
-}
-
-// WriteLeb128To writes a LEB128 encoded value to buf and returns bytes written.
-func WriteLeb128To(buf []byte, in uint) int {
-	for i := range buf {
-		buf[i] = byte(in & 0x7f)
-		in >>= 7
-		if in == 0 {
-			return i + 1
-		}
-		buf[i] |= 0x80
-	}
-
-	return 0
-}

--- a/codecs/av1/obu/leb128.go
+++ b/codecs/av1/obu/leb128.go
@@ -83,3 +83,27 @@ func WriteToLeb128(in uint) []byte {
 
 	return b // unreachable
 }
+
+// Leb128Size returns the number of bytes needed to encode a value as LEB128.
+func Leb128Size(in uint) int {
+	size := 1
+	for in >>= 7; in != 0; in >>= 7 {
+		size++
+	}
+
+	return size
+}
+
+// WriteLeb128To writes a LEB128 encoded value to buf and returns bytes written.
+func WriteLeb128To(buf []byte, in uint) int {
+	for i := range buf {
+		buf[i] = byte(in & 0x7f)
+		in >>= 7
+		if in == 0 {
+			return i + 1
+		}
+		buf[i] |= 0x80
+	}
+
+	return 0
+}

--- a/codecs/av1/obu/leb128.go
+++ b/codecs/av1/obu/leb128.go
@@ -83,4 +83,3 @@ func WriteToLeb128(in uint) []byte {
 
 	return b // unreachable
 }
-

--- a/playoutdelayextension_test.go
+++ b/playoutdelayextension_test.go
@@ -61,3 +61,14 @@ func TestPlayoutDelayExtensionExtraBytes(t *testing.T) {
 
 	assert.Equal(t, t1, t2)
 }
+
+var playoutDelaySink []byte
+
+func BenchmarkPlayoutDelayExtension_Marshal(b *testing.B) {
+	ext := PlayoutDelayExtension{MinDelay: 100, MaxDelay: 200}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		playoutDelaySink, _ = ext.Marshal()
+	}
+}

--- a/playoutdelayextension_test.go
+++ b/playoutdelayextension_test.go
@@ -4,6 +4,7 @@
 package rtp
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,9 @@ func TestPlayoutDelayExtensionTooLarge(t *testing.T) {
 	t1 := PlayoutDelayExtension{MinDelay: 1 << 12, MaxDelay: 1 << 12}
 
 	_, err := t1.Marshal()
+	assert.ErrorIs(t, err, errPlayoutDelayInvalidValue)
+
+	_, err = t1.MarshalTo(make([]byte, 10))
 	assert.ErrorIs(t, err, errPlayoutDelayInvalidValue)
 }
 
@@ -62,7 +66,27 @@ func TestPlayoutDelayExtensionExtraBytes(t *testing.T) {
 	assert.Equal(t, t1, t2)
 }
 
-var playoutDelaySink []byte
+func TestPlayoutDelayExtensionMarshalTo(t *testing.T) {
+	ext := PlayoutDelayExtension{MinDelay: 100, MaxDelay: 200}
+
+	buf := make([]byte, ext.MarshalSize())
+	n, err := ext.MarshalTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, ext.MarshalSize(), n)
+
+	expected, _ := ext.Marshal()
+	assert.Equal(t, expected, buf)
+
+	_, err = ext.MarshalTo(nil)
+	assert.ErrorIs(t, err, io.ErrShortBuffer)
+}
+
+//nolint:gochecknoglobals
+var (
+	playoutDelaySink    []byte
+	playoutDelayBuf     = make([]byte, playoutDelayExtensionSize)
+	playoutDelaySinkInt int
+)
 
 func BenchmarkPlayoutDelayExtension_Marshal(b *testing.B) {
 	ext := PlayoutDelayExtension{MinDelay: 100, MaxDelay: 200}
@@ -70,5 +94,14 @@ func BenchmarkPlayoutDelayExtension_Marshal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		playoutDelaySink, _ = ext.Marshal()
+	}
+}
+
+func BenchmarkPlayoutDelayExtension_MarshalTo(b *testing.B) {
+	ext := PlayoutDelayExtension{MinDelay: 100, MaxDelay: 200}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		playoutDelaySinkInt, _ = ext.MarshalTo(playoutDelayBuf)
 	}
 }

--- a/transportccextension.go
+++ b/transportccextension.go
@@ -5,6 +5,7 @@ package rtp
 
 import (
 	"encoding/binary"
+	"io"
 )
 
 const (
@@ -24,6 +25,22 @@ const (
 // .
 type TransportCCExtension struct {
 	TransportSequence uint16
+}
+
+// MarshalSize returns the size of the TransportCCExtension once marshaled.
+func (t TransportCCExtension) MarshalSize() int {
+	return transportCCExtensionSize
+}
+
+// MarshalTo marshals the extension to the given buffer.
+// Returns io.ErrShortBuffer if buf is too small.
+func (t TransportCCExtension) MarshalTo(buf []byte) (int, error) {
+	if len(buf) < transportCCExtensionSize {
+		return 0, io.ErrShortBuffer
+	}
+	binary.BigEndian.PutUint16(buf[0:2], t.TransportSequence)
+
+	return transportCCExtensionSize, nil
 }
 
 // Marshal serializes the members to buffer.

--- a/transportccextension_test.go
+++ b/transportccextension_test.go
@@ -4,6 +4,7 @@
 package rtp
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,7 +56,27 @@ func TestTransportCCExtensionExtraBytes(t *testing.T) {
 	assert.Equal(t, t1, t2)
 }
 
-var transportCCSink []byte
+func TestTransportCCExtensionMarshalTo(t *testing.T) {
+	ext := TransportCCExtension{TransportSequence: 1234}
+
+	buf := make([]byte, ext.MarshalSize())
+	n, err := ext.MarshalTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, ext.MarshalSize(), n)
+
+	expected, _ := ext.Marshal()
+	assert.Equal(t, expected, buf)
+
+	_, err = ext.MarshalTo(nil)
+	assert.ErrorIs(t, err, io.ErrShortBuffer)
+}
+
+//nolint:gochecknoglobals
+var (
+	transportCCSink    []byte
+	transportCCBuf     = make([]byte, transportCCExtensionSize)
+	transportCCSinkInt int
+)
 
 func BenchmarkTransportCCExtension_Marshal(b *testing.B) {
 	ext := TransportCCExtension{TransportSequence: 1234}
@@ -63,5 +84,14 @@ func BenchmarkTransportCCExtension_Marshal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		transportCCSink, _ = ext.Marshal()
+	}
+}
+
+func BenchmarkTransportCCExtension_MarshalTo(b *testing.B) {
+	ext := TransportCCExtension{TransportSequence: 1234}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		transportCCSinkInt, _ = ext.MarshalTo(transportCCBuf)
 	}
 }

--- a/transportccextension_test.go
+++ b/transportccextension_test.go
@@ -54,3 +54,14 @@ func TestTransportCCExtensionExtraBytes(t *testing.T) {
 
 	assert.Equal(t, t1, t2)
 }
+
+var transportCCSink []byte
+
+func BenchmarkTransportCCExtension_Marshal(b *testing.B) {
+	ext := TransportCCExtension{TransportSequence: 1234}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		transportCCSink, _ = ext.Marshal()
+	}
+}

--- a/vlaextension.go
+++ b/vlaextension.go
@@ -90,7 +90,7 @@ func (v VLA) calcTargetBitratesSize(ctx *vlaMarshalingContext) {
 		for spatialID := 0; spatialID < 4; spatialID++ {
 			if idx := ctx.slIndices[rtpStreamID][spatialID]; idx >= 0 {
 				for _, kbps := range v.ActiveSpatialLayer[idx].TargetBitrates {
-					ctx.requiredLen += obu.Leb128Size(uint(kbps)) //nolint:gosec
+					ctx.requiredLen += leb128Size(uint(kbps)) //nolint:gosec
 				}
 			}
 		}
@@ -194,7 +194,7 @@ func (v VLA) MarshalTo(buf []byte) (int, error) { //nolint:cyclop,gocognit
 		for spatialID := 0; spatialID < 4; spatialID++ {
 			if idx := ctx.slIndices[rtpStreamID][spatialID]; idx >= 0 {
 				for _, kbps := range v.ActiveSpatialLayer[idx].TargetBitrates {
-					offset += obu.WriteLeb128To(buf[offset:], uint(kbps)) //nolint:gosec
+					offset += writeLeb128To(buf[offset:], uint(kbps)) //nolint:gosec
 				}
 			}
 		}
@@ -408,4 +408,28 @@ func (v VLA) String() string {
 	out += fmt.Sprintf(",ActiveSpatialLayers:{%s}", strings.Join(slOut, ","))
 
 	return out
+}
+
+// leb128Size returns the number of bytes needed to encode a value as LEB128.
+func leb128Size(in uint) int {
+	size := 1
+	for in >>= 7; in != 0; in >>= 7 {
+		size++
+	}
+
+	return size
+}
+
+// writeLeb128To writes a LEB128 encoded value to buf and returns bytes written.
+func writeLeb128To(buf []byte, in uint) int {
+	for i := range buf {
+		buf[i] = byte(in & 0x7f)
+		in >>= 7
+		if in == 0 {
+			return i + 1
+		}
+		buf[i] |= 0x80
+	}
+
+	return 0
 }

--- a/vlaextension.go
+++ b/vlaextension.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pion/rtp/codecs/av1/obu"
@@ -49,16 +50,22 @@ type VLA struct {
 }
 
 type vlaMarshalingContext struct {
-	slMBs                 [4]uint8
-	sls                   [4][4]*SpatialLayer
-	commonSLBM            uint8
-	encodedTargetBitrates [][]byte
-	requiredLen           int
+	slMBs       [4]uint8
+	slIndices   [4][4]int // index into ActiveSpatialLayer, -1 if not set
+	commonSLBM  uint8
+	requiredLen int
 }
 
-func (v VLA) preprocessForMashaling(ctx *vlaMarshalingContext) error {
-	for i := 0; i < len(v.ActiveSpatialLayer); i++ {
-		sl := v.ActiveSpatialLayer[i]
+func (v VLA) preprocessForMashaling(ctx *vlaMarshalingContext) error { //nolint:cyclop
+	// Initialize indices to -1 (not set)
+	for i := range ctx.slIndices {
+		for j := range ctx.slIndices[i] {
+			ctx.slIndices[i][j] = -1
+		}
+	}
+
+	for i := range v.ActiveSpatialLayer {
+		sl := &v.ActiveSpatialLayer[i]
 		if sl.RTPStreamID < 0 || sl.RTPStreamID >= v.RTPStreamCount {
 			return fmt.Errorf("invalid RTP streamID %d:%w", sl.RTPStreamID, ErrVLAInvalidStreamID)
 		}
@@ -69,43 +76,40 @@ func (v VLA) preprocessForMashaling(ctx *vlaMarshalingContext) error {
 			return fmt.Errorf("invalid temporal layer count %d: %w", len(sl.TargetBitrates), ErrVLAInvalidTemporalLayer)
 		}
 		ctx.slMBs[sl.RTPStreamID] |= 1 << sl.SpatialID
-		if ctx.sls[sl.RTPStreamID][sl.SpatialID] != nil {
+		if ctx.slIndices[sl.RTPStreamID][sl.SpatialID] != -1 {
 			return fmt.Errorf("duplicate spatial layer: %w", ErrVLADuplicateSpatialID)
 		}
-		ctx.sls[sl.RTPStreamID][sl.SpatialID] = &sl
+		ctx.slIndices[sl.RTPStreamID][sl.SpatialID] = i
 	}
 
 	return nil
 }
 
-func (v VLA) encodeTargetBitrates(ctx *vlaMarshalingContext) {
+func (v VLA) calcTargetBitratesSize(ctx *vlaMarshalingContext) {
 	for rtpStreamID := 0; rtpStreamID < v.RTPStreamCount; rtpStreamID++ {
 		for spatialID := 0; spatialID < 4; spatialID++ {
-			if sl := ctx.sls[rtpStreamID][spatialID]; sl != nil {
-				for _, kbps := range sl.TargetBitrates {
-					leb128 := obu.WriteToLeb128(uint(kbps)) // nolint: gosec
-					ctx.encodedTargetBitrates = append(ctx.encodedTargetBitrates, leb128)
-					ctx.requiredLen += len(leb128)
+			if idx := ctx.slIndices[rtpStreamID][spatialID]; idx >= 0 {
+				for _, kbps := range v.ActiveSpatialLayer[idx].TargetBitrates {
+					ctx.requiredLen += obu.Leb128Size(uint(kbps)) //nolint:gosec
 				}
 			}
 		}
 	}
 }
 
-func (v VLA) analyzeVLAForMarshaling() (*vlaMarshalingContext, error) {
+func (v VLA) analyzeVLAForMarshaling(ctx *vlaMarshalingContext) error {
 	// Validate RTPStreamCount
 	if v.RTPStreamCount <= 0 || v.RTPStreamCount > 4 {
-		return nil, ErrVLAInvalidStreamCount
+		return ErrVLAInvalidStreamCount
 	}
 	// Validate RTPStreamID
 	if v.RTPStreamID < 0 || v.RTPStreamID >= v.RTPStreamCount {
-		return nil, ErrVLAInvalidStreamID
+		return ErrVLAInvalidStreamID
 	}
 
-	ctx := &vlaMarshalingContext{}
 	err := v.preprocessForMashaling(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	ctx.commonSLBM = commonSLBMValues(ctx.slMBs[:])
@@ -120,35 +124,49 @@ func (v VLA) analyzeVLAForMarshaling() (*vlaMarshalingContext, error) {
 	// #tl fields
 	ctx.requiredLen += (len(v.ActiveSpatialLayer)-1)/4 + 1
 
-	v.encodeTargetBitrates(ctx)
+	v.calcTargetBitratesSize(ctx)
 
 	if v.HasResolutionAndFramerate {
 		ctx.requiredLen += len(v.ActiveSpatialLayer) * 5
 	}
 
-	return ctx, nil
+	return nil
 }
 
-// Marshal encodes VLA into a byte slice.
-func (v VLA) Marshal() ([]byte, error) { // nolint: cyclop
-	ctx, err := v.analyzeVLAForMarshaling()
-	if err != nil {
-		return nil, err
+// MarshalSize returns the size needed to marshal the VLA.
+func (v VLA) MarshalSize() (int, error) {
+	var ctx vlaMarshalingContext
+	if err := v.analyzeVLAForMarshaling(&ctx); err != nil {
+		return 0, err
 	}
 
-	payload := make([]byte, ctx.requiredLen)
+	return ctx.requiredLen, nil
+}
+
+// MarshalTo marshals the VLA to the given buffer.
+// Returns io.ErrShortBuffer if buf is too small.
+func (v VLA) MarshalTo(buf []byte) (int, error) { //nolint:cyclop,gocognit
+	var ctx vlaMarshalingContext
+	if err := v.analyzeVLAForMarshaling(&ctx); err != nil {
+		return 0, err
+	}
+
+	if len(buf) < ctx.requiredLen {
+		return 0, io.ErrShortBuffer
+	}
+
 	offset := 0
 
 	// RID, NS, sl_bm fields
-	payload[offset] = byte(v.RTPStreamID<<6) | byte(v.RTPStreamCount-1)<<4 | ctx.commonSLBM
+	buf[offset] = byte(v.RTPStreamID<<6) | byte(v.RTPStreamCount-1)<<4 | ctx.commonSLBM
 
 	if ctx.commonSLBM == 0 {
 		offset++
 		for streamID := 0; streamID < v.RTPStreamCount; streamID++ {
 			if streamID%2 == 0 {
-				payload[offset+streamID/2] |= ctx.slMBs[streamID] << 4
+				buf[offset+streamID/2] |= ctx.slMBs[streamID] << 4
 			} else {
-				payload[offset+streamID/2] |= ctx.slMBs[streamID]
+				buf[offset+streamID/2] |= ctx.slMBs[streamID]
 			}
 		}
 		offset += (v.RTPStreamCount - 1) / 2
@@ -159,12 +177,12 @@ func (v VLA) Marshal() ([]byte, error) { // nolint: cyclop
 	var temporalLayerIndex int
 	for rtpStreamID := 0; rtpStreamID < v.RTPStreamCount; rtpStreamID++ {
 		for spatialID := 0; spatialID < 4; spatialID++ {
-			if sl := ctx.sls[rtpStreamID][spatialID]; sl != nil {
+			if idx := ctx.slIndices[rtpStreamID][spatialID]; idx >= 0 {
 				if temporalLayerIndex >= 4 {
 					temporalLayerIndex = 0
 					offset++
 				}
-				payload[offset] |= byte(len(sl.TargetBitrates)-1) << (2 * (3 - temporalLayerIndex))
+				buf[offset] |= byte(len(v.ActiveSpatialLayer[idx].TargetBitrates)-1) << (2 * (3 - temporalLayerIndex))
 				temporalLayerIndex++
 			}
 		}
@@ -172,23 +190,43 @@ func (v VLA) Marshal() ([]byte, error) { // nolint: cyclop
 
 	// Target bitrate fields
 	offset++
-	for _, encodedKbps := range ctx.encodedTargetBitrates {
-		encodedSize := len(encodedKbps)
-		copy(payload[offset:], encodedKbps)
-		offset += encodedSize
+	for rtpStreamID := 0; rtpStreamID < v.RTPStreamCount; rtpStreamID++ {
+		for spatialID := 0; spatialID < 4; spatialID++ {
+			if idx := ctx.slIndices[rtpStreamID][spatialID]; idx >= 0 {
+				for _, kbps := range v.ActiveSpatialLayer[idx].TargetBitrates {
+					offset += obu.WriteLeb128To(buf[offset:], uint(kbps)) //nolint:gosec
+				}
+			}
+		}
 	}
 
 	// Resolution & framerate fields
 	if v.HasResolutionAndFramerate {
 		for _, sl := range v.ActiveSpatialLayer {
-			binary.BigEndian.PutUint16(payload[offset+0:], uint16(sl.Width-1))  // nolint: gosec
-			binary.BigEndian.PutUint16(payload[offset+2:], uint16(sl.Height-1)) // nolint: gosec
-			payload[offset+4] = byte(sl.Framerate)
+			binary.BigEndian.PutUint16(buf[offset+0:], uint16(sl.Width-1))  //nolint:gosec
+			binary.BigEndian.PutUint16(buf[offset+2:], uint16(sl.Height-1)) //nolint:gosec
+			buf[offset+4] = byte(sl.Framerate)
 			offset += 5
 		}
 	}
 
-	return payload, nil
+	return ctx.requiredLen, nil
+}
+
+// Marshal encodes VLA into a byte slice.
+func (v VLA) Marshal() ([]byte, error) {
+	size, err := v.MarshalSize()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, size)
+	_, err = v.MarshalTo(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
 }
 
 func commonSLBMValues(slMBs []uint8) uint8 {

--- a/vlaextension_test.go
+++ b/vlaextension_test.go
@@ -457,3 +457,22 @@ func FuzzVLAUnmarshal(f *testing.F) {
 		}
 	})
 }
+
+var vlaSink []byte
+
+func BenchmarkVLA_Marshal(b *testing.B) {
+	vla := &VLA{
+		RTPStreamID:    0,
+		RTPStreamCount: 3,
+		ActiveSpatialLayer: []SpatialLayer{
+			{RTPStreamID: 0, SpatialID: 0, TargetBitrates: []int{150}},
+			{RTPStreamID: 1, SpatialID: 0, TargetBitrates: []int{240, 400}},
+			{RTPStreamID: 2, SpatialID: 0, TargetBitrates: []int{720, 1200}},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vlaSink, _ = vla.Marshal()
+	}
+}

--- a/vlaextension_test.go
+++ b/vlaextension_test.go
@@ -5,6 +5,7 @@ package rtp
 
 import (
 	"encoding/hex"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -458,7 +459,38 @@ func FuzzVLAUnmarshal(f *testing.F) {
 	})
 }
 
-var vlaSink []byte
+func TestVLAMarshalTo(t *testing.T) {
+	vla := &VLA{
+		RTPStreamID:    0,
+		RTPStreamCount: 3,
+		ActiveSpatialLayer: []SpatialLayer{
+			{RTPStreamID: 0, SpatialID: 0, TargetBitrates: []int{150}},
+			{RTPStreamID: 1, SpatialID: 0, TargetBitrates: []int{240, 400}},
+			{RTPStreamID: 2, SpatialID: 0, TargetBitrates: []int{720, 1200}},
+		},
+	}
+
+	size, err := vla.MarshalSize()
+	assert.NoError(t, err)
+
+	buf := make([]byte, size)
+	n, err := vla.MarshalTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, size, n)
+
+	expected, _ := vla.Marshal()
+	assert.Equal(t, expected, buf)
+
+	_, err = vla.MarshalTo(nil)
+	assert.ErrorIs(t, err, io.ErrShortBuffer)
+}
+
+//nolint:gochecknoglobals
+var (
+	vlaSink    []byte
+	vlaBuf     = make([]byte, 256)
+	vlaSinkInt int
+)
 
 func BenchmarkVLA_Marshal(b *testing.B) {
 	vla := &VLA{
@@ -474,5 +506,22 @@ func BenchmarkVLA_Marshal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		vlaSink, _ = vla.Marshal()
+	}
+}
+
+func BenchmarkVLA_MarshalTo(b *testing.B) {
+	vla := &VLA{
+		RTPStreamID:    0,
+		RTPStreamCount: 3,
+		ActiveSpatialLayer: []SpatialLayer{
+			{RTPStreamID: 0, SpatialID: 0, TargetBitrates: []int{150}},
+			{RTPStreamID: 1, SpatialID: 0, TargetBitrates: []int{240, 400}},
+			{RTPStreamID: 2, SpatialID: 0, TargetBitrates: []int{720, 1200}},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vlaSinkInt, _ = vla.MarshalTo(vlaBuf)
 	}
 }


### PR DESCRIPTION
Add MarshalTo and MarshalSize methods to RTP header extensions for zero-allocation marshaling to pre-allocated buffers. This avoids a few allocations per packet when setting multiple extensions.

  Extensions updated:
  - AbsSendTimeExtension
  - AbsCaptureTimeExtension
  - AudioLevelExtension
  - TransportCCExtension
  - PlayoutDelayExtension

  Benchmarks
```
  goos: darwin
  goarch: arm64
  pkg: github.com/pion/rtp
  cpu: Apple M2 Pro
  BenchmarkAbsCaptureTimeExtension_Marshal-10           128185942                9.36 ns/op            8 B/op          1 allocs/op
  BenchmarkAbsCaptureTimeExtension_MarshalTo-10         1000000000               0.95 ns/op            0 B/op          0 allocs/op
  BenchmarkAbsSendTimeExtension_Marshal-10              151077481                8.18 ns/op            3 B/op          1 allocs/op
  BenchmarkAbsSendTimeExtension_MarshalTo-10            1000000000               0.71 ns/op            0 B/op          0 allocs/op
  BenchmarkAudioLevelExtension_Marshal-10               163556499                7.40 ns/op            1 B/op          1 allocs/op
  BenchmarkAudioLevelExtension_MarshalTo-10             1000000000               0.63 ns/op            0 B/op          0 allocs/op
  BenchmarkPlayoutDelayExtension_Marshal-10             142778154                8.32 ns/op            3 B/op          1 allocs/op
  BenchmarkPlayoutDelayExtension_MarshalTo-10           1000000000               0.71 ns/op            0 B/op          0 allocs/op
  BenchmarkTransportCCExtension_Marshal-10              152836818                7.92 ns/op            2 B/op          1 allocs/op
  BenchmarkTransportCCExtension_MarshalTo-10            1000000000               0.67 ns/op            0 B/op          0 allocs/op
```